### PR TITLE
fix: preserve Qwen voice cloning model selection

### DIFF
--- a/pandrator/logic/tts_handler.py
+++ b/pandrator/logic/tts_handler.py
@@ -794,7 +794,7 @@ def _merge_service_config(
     for key in ("request_fields", "request_defaults"):
         if isinstance(raw_record.get(key), dict):
             record[key] = copy.deepcopy(raw_record[key])
-    for key in ("settings", "voice_catalogues", "default_voices", "default_voices_by_language", "pricing"):
+    for key in ("settings", "voice_catalogues", "voice_metadata", "default_voices", "default_voices_by_language", "pricing"):
         if isinstance(raw_record.get(key), dict):
             record[key] = copy.deepcopy(raw_record[key])
     if PREBUILT_VOICE_PROVIDER_FIELD in raw_record:
@@ -4585,14 +4585,58 @@ def _request_chatterbox_audio(text: str, tts_settings: dict, chatterbox_base_url
     raise RuntimeError(f"No Chatterbox speech endpoint could be resolved for '{normalized_base_url}'.")
 
 
+def _kobold_qwen_cloning_model_from_metadata(tts_settings: dict, voice: str) -> str:
+    """Return the catalogue model for a cloned Qwen voice, when supplied."""
+    if not voice:
+        return ""
+    metadata_sources = [tts_settings.get("voice_metadata")]
+    metadata_sources.extend(
+        item.get("voice_metadata")
+        for item in tts_settings.get("provider_configs", [])
+        if isinstance(item, dict)
+    )
+    for metadata in metadata_sources:
+        if not isinstance(metadata, dict):
+            continue
+        for key, item in metadata.items():
+            if not isinstance(item, dict):
+                continue
+            voice_id = str(item.get("id") or item.get("voice_id") or "").strip()
+            if not voice_id and ":" in str(key):
+                voice_id = str(key).rsplit(":", 1)[-1].strip()
+            if voice_id.lower() != voice.lower():
+                continue
+            voice_type = str(item.get("type") or "").strip().lower()
+            if voice_type and voice_type != "preset":
+                return "Voice Cloning"
+            model = str(item.get("model") or "").strip()
+            if model.lower() in {"voice cloning", "qwen3-tts", "qwen3-tts-base"}:
+                return "Voice Cloning"
+    return ""
+
+
+def resolve_kobold_qwen_model(tts_settings: dict, fallback: str = KOBOLD_QWEN_DEFAULT_MODEL) -> str:
+    """Resolve Qwen's current model field before its legacy XTTS alias.
+
+    A voice catalogue can identify a cloned reference even when no model was
+    selected yet; in that case the only compatible Qwen model is Voice Cloning.
+    Explicit model selections deliberately remain authoritative so validation
+    can reject an incompatible explicit pairing instead of masking it.
+    """
+    model = str(tts_settings.get("model") or "").strip()
+    if model:
+        return model
+    legacy_model = str(tts_settings.get("xtts_model") or "").strip()
+    if legacy_model:
+        return legacy_model
+    voice = str(tts_settings.get("speaker") or tts_settings.get("voice") or "").strip()
+    return _kobold_qwen_cloning_model_from_metadata(tts_settings, voice) or fallback
+
+
 def _request_kobold_qwen_audio(text: str, tts_settings: dict, kobold_qwen_base_url: str) -> requests.Response:
     normalized_base_url = _normalize_base_url(kobold_qwen_base_url, KOBOLD_QWEN_API_BASE_URL)
     api_key = _resolve_kobold_qwen_api_key(tts_settings)
-    model = str(
-        tts_settings.get("xtts_model")
-        or tts_settings.get("model")
-        or KOBOLD_QWEN_DEFAULT_MODEL
-    ).strip()
+    model = resolve_kobold_qwen_model(tts_settings)
     if not model:
         model = KOBOLD_QWEN_DEFAULT_MODEL
 

--- a/pandrator/web/tts_providers.py
+++ b/pandrator/web/tts_providers.py
@@ -805,8 +805,6 @@ class TtsCatalogueService:
             or service_id
         )
         resolved_model = model or str(service.get("default_model") or "")
-        if resolved_id == "kobold_qwen":
-            resolved_model = tts_handler.KOBOLD_QWEN_DEFAULT_MODEL
         default_voices = (
             service.get("default_voices")
             if isinstance(service.get("default_voices"), dict)

--- a/pandrator/web/workspace.py
+++ b/pandrator/web/workspace.py
@@ -686,7 +686,13 @@ class WorkspaceSettingsService:
             provider_defaults = selected.get("settings") if selected and isinstance(selected.get("settings"), dict) else {}
             resolved["tts"] = _merge(snapshot["builtin"], snapshot["global"], connection_value, provider_defaults, snapshot.get("session_context", {}), snapshot["override"], override.get("tts", {}))
             if selected:
-                model = str(resolved["tts"].get("model") or selected.get("default_model") or "")
+                if str(selected.get("id") or "").lower() == "kobold_qwen":
+                    model = tts_handler.resolve_kobold_qwen_model(
+                        resolved["tts"],
+                        fallback=str(selected.get("default_model") or ""),
+                    )
+                else:
+                    model = str(resolved["tts"].get("model") or selected.get("default_model") or "")
                 default_voices = selected.get("default_voices") if isinstance(selected.get("default_voices"), dict) else {}
                 language_defaults = selected.get("default_voices_by_language") if isinstance(selected.get("default_voices_by_language"), dict) else {}
                 model_language_defaults = language_defaults.get(model) if isinstance(language_defaults.get(model), dict) else {}

--- a/tests/test_tts_handler.py
+++ b/tests/test_tts_handler.py
@@ -639,7 +639,7 @@ class TTSHandlerTests(unittest.TestCase):
                 "Hello world",
                 {
                     "model": "Prebuilt Voices",
-                    "voice": "Ryan",
+                    "voice": "Aiden",
                     "generation_prompt": "Sound excited but controlled.",
                 },
                 "http://localhost:8042",
@@ -676,6 +676,35 @@ class TTSHandlerTests(unittest.TestCase):
                 {"model": "Prebuilt Voices", "voice": "my-uploaded-voice"},
                 "http://localhost:8042",
             )
+
+    def test_kobold_qwen_current_model_overrides_stale_legacy_alias(self):
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            tts_handler._request_kobold_qwen_audio(
+                "Hello world",
+                {
+                    "model": "Voice Cloning",
+                    "xtts_model": "Prebuilt Voices",
+                    "voice": "cloned-voice",
+                },
+                "http://localhost:8042",
+            )
+
+        self.assertEqual("Voice Cloning", mock_post.call_args.kwargs["json"]["model"])
+        self.assertEqual("cloned-voice", mock_post.call_args.kwargs["json"]["voice"])
+
+    def test_kobold_qwen_metadata_resolves_an_unselected_cloned_voice(self):
+        settings = {
+            "voice": "cloned-voice",
+            "voice_metadata": {
+                "Voice Cloning:cloned-voice": {
+                    "id": "cloned-voice",
+                    "type": "cloned",
+                    "model": "Voice Cloning",
+                }
+            },
+        }
+        self.assertEqual("Voice Cloning", tts_handler.resolve_kobold_qwen_model(settings))
 
     def test_kobold_qwen_catalogue_seeds_kobo_as_a_cloning_voice(self):
         with patch(

--- a/tests/test_web_parity_workspace.py
+++ b/tests/test_web_parity_workspace.py
@@ -10,6 +10,7 @@ from pandrator.web.api import create_app
 from pandrator.web.artifacts import ArtifactService
 from pandrator.web.auth import BootstrapTokenStore
 from pandrator.web.models import AppSetting, Artifact, AudioTake, GenerationRun, GenerationSegment, Job, UsageEvent
+from pandrator.web.tts_providers import KoboldQwenAdapter
 from pandrator.web.workspace import BUILTIN_DEFAULTS, adapt_runtime_settings
 from tests.web_test_support import prepare_web_test_data_root
 
@@ -59,6 +60,30 @@ class WebParityWorkspaceTests(unittest.TestCase):
         self.assertEqual("http://127.0.0.1:8880", resolved["value"]["tts"]["kokoro_base_url"])
         self.assertEqual("local", resolved["value"]["tts"]["provider_configs"][0]["id"])
         self.assertEqual(64, len(resolved["settings_hash"]))
+
+    def test_qwen_voice_cloning_selection_survives_the_run_snapshot_resolution(self):
+        record = self.create_session()
+        saved = self.client.put(
+            f"/api/v1/sessions/{record['id']}/settings/tts",
+            json={
+                "value": {
+                    "service": "kobold_qwen",
+                    "model": "Voice Cloning",
+                    "xtts_model": "Prebuilt Voices",
+                    "voice": "cloned-voice",
+                }
+            },
+            headers={**self.headers, "If-Match": '"0"'},
+        )
+        self.assertEqual(200, saved.status_code, saved.get_json())
+        resolved = self.client.post(
+            f"/api/v1/sessions/{record['id']}/settings/resolve",
+            json={"sections": ["tts"]},
+            headers=self.headers,
+        ).get_json()["value"]["tts"]
+
+        self.assertEqual("Voice Cloning", resolved["model"])
+        self.assertEqual("cloned-voice", resolved["voice"])
 
     def test_global_defaults_endpoint_exposes_builtins_and_revisioned_values(self):
         services = self.client.get("/api/v1/services/tts").get_json()
@@ -198,17 +223,17 @@ class WebParityWorkspaceTests(unittest.TestCase):
         self.assertEqual("af_heart", payload["settings"]["voice"])
         self.assertEqual("en", payload["settings"]["language"])
 
-    def test_qwen_prebuilt_preview_always_selects_customvoice_model(self):
+    def test_qwen_preview_preserves_the_selected_voice_cloning_model(self):
         response = self.client.post(
             "/api/v1/services/tts/kobold_qwen/preview",
-            json={"text": "A Qwen preview.", "model": "Voice Cloning", "voice": "Ryan", "language": "en"},
+            json={"text": "A Qwen preview.", "model": "Voice Cloning", "voice": "cloned-voice", "language": "en"},
             headers=self.headers,
         )
         self.assertEqual(202, response.status_code, response.get_json())
         settings = response.get_json()["payload_json"]["settings"]
-        self.assertEqual("Prebuilt Voices", settings["model"])
-        self.assertEqual("Prebuilt Voices", settings["xtts_model"])
-        self.assertEqual("Ryan", settings["voice"])
+        self.assertEqual("Voice Cloning", settings["model"])
+        self.assertEqual("Voice Cloning", settings["xtts_model"])
+        self.assertEqual("cloned-voice", settings["voice"])
         catalogue = self.client.get("/api/v1/services/tts").get_json()
         qwen = next(item for item in catalogue["services"] if item["id"] == "kobold_qwen")
         self.assertEqual(
@@ -219,6 +244,28 @@ class WebParityWorkspaceTests(unittest.TestCase):
         self.assertEqual("kobo", qwen["default_voices"]["Voice Cloning"])
         self.assertIn("Prebuilt Voices", qwen["generation_prompt_models"])
         self.assertNotIn("Voice Cloning", qwen["generation_prompt_models"])
+
+    def test_qwen_catalogue_refresh_preserves_an_available_saved_default_model(self):
+        adapter = KoboldQwenAdapter("kobold_qwen")
+        service = {
+            "api_base": "http://localhost:8042",
+            "default_model": "Voice Cloning",
+        }
+        with patch(
+            "pandrator.logic.tts_handler.get_kobold_qwen_voice_catalog",
+            return_value=[
+                {"id": "Aiden", "type": "preset", "model": "Prebuilt Voices"},
+                {"id": "cloned-voice", "type": "cloned", "model": "Voice Cloning"},
+            ],
+        ):
+            refreshed = adapter.enrich_catalog(service)
+
+        self.assertEqual("Voice Cloning", service["default_model"])
+        self.assertEqual(["cloned-voice"], refreshed["voices"])
+        self.assertEqual(
+            "cloned",
+            refreshed["voice_metadata"]["Voice Cloning:cloned-voice"]["type"],
+        )
 
     def test_tts_catalogue_restores_managed_previews_and_marks_unavailable_services(self):
         extension = self.app.extensions["pandrator"]


### PR DESCRIPTION
## Summary

Fix Qwen3-TTS generation incorrectly resolving a stale legacy `xtts_model`
value ahead of the current TTS `model` selection.

## Reproduction

1. Select Qwen3 TTS.
2. Select `Voice Cloning` and a registered cloned reference.
3. Retain a stale legacy `xtts_model=Prebuilt Voices` value.
4. Start generation.

Before this change, Pandrator resolved `Prebuilt Voices` locally and rejected
the cloned reference before issuing a synthesis request.

## Changes

- Prefer the current Qwen `model` over the legacy `xtts_model` alias.
- Preserve `Voice Cloning` through preview creation and generation-run setting
  resolution.
- Retain Qwen voice metadata through service-config merging and infer
  `Voice Cloning` only when no model was explicitly selected.
- Keep explicit incompatible `Prebuilt Voices` / cloned-reference combinations
  rejected.
- Add regressions for cloning resolution, legacy compatibility, prebuilt Aiden,
  preview settings, run snapshots, and catalogue-default preservation.

## Validation

- `61 passed`:
  `tests/test_tts_handler.py tests/test_web_parity_workspace.py`
- Python compilation passed for all changed Python files.
- `git diff --check` passed.
- Live generation was successfully confirmed with Qwen3-TTS Base 1.7B.