### PR TITLE
fix: refresh regenerated segments in filtered views

### DIFF
--- a/web/src/lib/generation-store.svelte.ts
+++ b/web/src/lib/generation-store.svelte.ts
@@ -62,6 +62,9 @@ export class GenerationStore {
   status = $state<LoadState>('idle');
   error = $state('');
   private loadedFilter: SegmentFilter | '' = '';
+  private loadedRunId = '';
+  private loadedPlanRevisionId: string | null = null;
+  private loadedThroughOrdinal = -1;
   private initialized = false;
   private controller?: AbortController;
   private unsubscribe?: () => void;
@@ -134,27 +137,53 @@ export class GenerationStore {
       } else if (
         preserveLoaded
         && this.loadedFilter === filter
+        && this.loadedRunId === selectedRunId
         && this.payload.plan_revision_id === next.plan_revision_id
-        && this.payload.items.length > next.items.length
+        && this.loadedThroughOrdinal > (next.items.at(-1)?.ordinal ?? -1)
       ) {
-        const incoming = new Map(next.items.map((item) => [item.id, item]));
-        const lastOrdinal = next.items.at(-1)?.ordinal ?? -1;
+        const items = [...next.items];
+        const known = new Set(items.map((item) => item.id));
+        const lastLoadedOrdinal = this.loadedThroughOrdinal;
+        let nextCursor = next.next_cursor;
+        while (
+          nextCursor != null
+          && (items.at(-1)?.ordinal ?? -1) < lastLoadedOrdinal
+        ) {
+          const pageQuery = new URLSearchParams(query);
+          pageQuery.set('cursor', String(nextCursor));
+          const page = await generationApi.segments(
+            this.sessionId,
+            pageQuery,
+            controller.signal
+          );
+          if (controller.signal.aborted) {
+            return { selectedRunId, shouldExpand: false };
+          }
+          items.push(...page.items.filter((item) => !known.has(item.id)));
+          for (const item of page.items) known.add(item.id);
+          nextCursor = page.next_cursor;
+        }
         payload = {
           ...next,
-          items: [
-            ...next.items,
-            ...this.payload.items.filter(
-              (item) => item.ordinal > lastOrdinal && !incoming.has(item.id)
-            )
-          ],
-          next_cursor: this.payload.next_cursor
+          items,
+          next_cursor: nextCursor
         };
       }
       this.payload = payload;
       this.runs = runs;
       this.activeRun = activeRun;
       this.assembly = latestAssembly.item;
+      const sameLoadedScope = (
+        this.loadedFilter === filter
+        && this.loadedRunId === selectedRunId
+        && this.loadedPlanRevisionId === payload.plan_revision_id
+      );
       this.loadedFilter = filter;
+      this.loadedRunId = selectedRunId;
+      this.loadedPlanRevisionId = payload.plan_revision_id;
+      this.loadedThroughOrdinal = sameLoadedScope
+        ? Math.max(this.loadedThroughOrdinal, payload.items.at(-1)?.ordinal ?? -1)
+        : payload.items.at(-1)?.ordinal ?? -1;
       const shouldExpand = this.initialized && (
         (previousTotal === 0 && payload.total > 0)
         || (

--- a/web/tests/workspace.spec.ts
+++ b/web/tests/workspace.spec.ts
@@ -346,6 +346,115 @@ test('generation segment search and replace preserves partial words and saves ev
   expect((await saved.json()).items.map((item: any) => item.text)).toEqual(['A dog waits.', 'A catfish and dog.']);
 });
 
+test('generated segments return to the current filtered page after repeated regeneration', async ({ page }) => {
+  let phase: 'completed' | 'running' = 'completed';
+  let generatedRefreshes = 0;
+  let generatedRunningRefreshes = 0;
+  const runId = 'generation-run';
+  const planRevisionId = 'generation-plan';
+  const completed = Array.from({ length: 102 }, (_, ordinal) => ({
+    id: `segment-${ordinal}`,
+    ordinal,
+    node_kind: 'paragraph',
+    paragraph_break_after: false,
+    text: `Generated segment ${ordinal + 1}.`,
+    optimized_text: null,
+    speech_plan: {},
+    optimization_status: 'not_requested',
+    optimization_reviewed: false,
+    marked: false,
+    removed: false,
+    status: 'completed',
+    revision: 1,
+    takes: []
+  }));
+  const failed = {
+    ...completed[0],
+    id: 'failed-segment',
+    ordinal: 102,
+    text: 'This failed segment must remain excluded.',
+    status: 'failed'
+  };
+  const run = () => ({
+    id: runId,
+    session_id: 'mock-session',
+    plan_revision_id: planRevisionId,
+    sequence_number: 1,
+    operation: 'generate',
+    label: 'Run 1: test',
+    job_id: 'generation-job',
+    status: phase,
+    progress: phase === 'completed' ? 1 : 0.5
+  });
+
+  await page.route('**/api/v1/events?after=*', (route) => route.abort());
+  await signIn(page);
+  const sessionId = await createGenerationPlan(page, [{ text: 'Placeholder.' }]);
+  await page.route(`**/api/v1/sessions/${sessionId}/generation-runs`, async (route) => {
+    if (route.request().method() === 'POST') {
+      phase = 'running';
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(run()) });
+      return;
+    }
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ items: [run()] }) });
+  });
+  await page.route(`**/api/v1/sessions/${sessionId}/output-assemblies/latest`, (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify({ item: null }) })
+  );
+  await page.route(`**/api/v1/sessions/${sessionId}/generation-segments?*`, async (route) => {
+    const query = new URL(route.request().url()).searchParams;
+    const visible = query.get('status') === 'completed'
+      ? completed.filter((item) => phase === 'completed' || item.ordinal !== 100)
+      : [...completed, failed];
+    if (query.get('status') === 'completed') {
+      generatedRefreshes += 1;
+      if (phase === 'running') generatedRunningRefreshes += 1;
+    }
+    const cursor = Number(query.get('cursor') ?? 0);
+    const items = visible.filter((item) => item.ordinal >= cursor).slice(0, 100);
+    const hasMore = visible.some((item) => item.ordinal > (items.at(-1)?.ordinal ?? -1));
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items,
+        total: visible.length,
+        next_cursor: hasMore ? (items.at(-1)?.ordinal ?? 0) + 1 : null,
+        plan_revision_id: planRevisionId
+      })
+    });
+  });
+
+  await page.goto(`/sessions/${sessionId}`);
+  await page.getByRole('button', { name: 'Generation', exact: true }).click();
+  const filter = page.getByLabel('Segments to display');
+  await page.getByRole('button', { name: 'Load more' }).click();
+  await expect(page.getByRole('button', { name: 'Regenerate segment 101' })).toBeVisible();
+  await page.getByRole('button', { name: 'Regenerate segment 101' }).click();
+  await expect(page.getByRole('button', { name: 'Regenerate segment 101' })).toBeVisible();
+  await expect(filter).toHaveValue('all');
+  phase = 'completed';
+
+  const completedRefreshesBeforeFilter = generatedRefreshes;
+  await filter.selectOption('completed');
+  await expect.poll(() => generatedRefreshes).toBeGreaterThan(completedRefreshesBeforeFilter);
+  await page.getByRole('button', { name: 'Load more' }).click();
+  await expect.poll(() => generatedRefreshes).toBeGreaterThan(completedRefreshesBeforeFilter + 1);
+  await expect(page.getByRole('button', { name: 'Regenerate segment 101' })).toBeVisible();
+  const versionPicker = page.locator('label.run-picker select');
+  await expect(versionPicker).toHaveValue(runId);
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await page.getByRole('button', { name: 'Regenerate segment 101' }).click();
+    await expect.poll(() => generatedRunningRefreshes).toBeGreaterThan(attempt);
+    phase = 'completed';
+    await expect(page.getByRole('button', { name: 'Regenerate segment 101' })).toBeVisible({ timeout: 12_000 });
+    await expect(filter).toHaveValue('completed');
+    await expect(versionPicker).toHaveValue(runId);
+    await expect(page.getByRole('button', { name: 'Regenerate segment 101' })).toHaveCount(1);
+    await expect(page.getByText('This failed segment must remain excluded.')).toHaveCount(0);
+  }
+});
+
 test('editorial workspace visual smoke', async ({ page }) => {
   const isWindows = await page.evaluate(() => navigator.userAgent.includes('Windows'));
   test.skip(isWindows, 'The visual baseline is captured on Linux to avoid platform font-metric differences.');


### PR DESCRIPTION
## Summary

Fix regenerated audio segments disappearing from the current Generation view
until the user manually changes the segment filter.

## Reproduction

1. Open an audiobook session’s Generation segment list.
2. Select either `All segments` or `Generated`.
3. Regenerate an individual segment.
4. Wait for regeneration to complete.

Previously, the regenerated segment could disappear from the current list.
Changing `Show` to a different filter caused it to appear there, indicating
that the current filtered view had not refreshed correctly.

## Root cause

During invalidation refreshes, `GenerationStore` used cached rows to fill a
temporarily shortened filtered response.

That cache tracked item count, but not the selected run or the full loaded
pagination range. A regeneration transition could therefore leave a paginated
filtered view with incomplete coverage, so the completed segment was not
authoritatively fetched again.

## Changes

- Track the loaded segment scope, including:
  - current filter
  - selected run
  - plan revision
  - highest loaded ordinal
- On an invalidation refresh that temporarily shortens the filtered response,
  fetch authoritative subsequent pages through the previously loaded range.
- Deduplicate refreshed rows instead of restoring stale cached rows.
- Preserve the selected filter, run, and pagination coverage.
- Add a Chromium regression covering:
  - `All segments`
  - `Generated`
  - repeated regeneration
  - paginated results
  - filter and selected-run preservation
  - duplicate prevention
  - exclusion of genuinely nonmatching failed segments

## Validation

- `svelte-check found 0 errors and 0 warnings`
- Focused Chromium regression: `1 passed`
- `git diff --check` passed
- Confirmed manually in the production frontend after rebuilding the web bundle