### PR TITLE
fix: synchronize project runtime after updates

### DIFF
--- a/pandrator_installer/pixi.py
+++ b/pandrator_installer/pixi.py
@@ -357,6 +357,24 @@ class PixiEnvironmentMixin:
             logging.error(f"Error output: {e.stderr}")
             raise
 
+    def sync_project_runtime(self, pandrator_path, project_path):
+        """Reinstall the launch environment from the updated project manifest.
+
+        ``pixi install`` may leave an already-recorded prefix untouched.  A
+        reinstall both refreshes editable project metadata and materializes the
+        complete locked runtime before the launcher selects its interpreter.
+        """
+        manifest_path = os.path.join(project_path, "pixi.toml")
+        if not os.path.isfile(manifest_path):
+            raise FileNotFoundError(
+                f"Pandrator Pixi manifest not found: {manifest_path}"
+            )
+        self.run_pixi_command(
+            pandrator_path,
+            ["reinstall", "--locked", "--manifest-path", manifest_path],
+            cwd=project_path,
+        )
+
     def add_pixi_conda_package(self, pandrator_path, env_name, package_spec):
         logging.info(f"Adding {package_spec} to {env_name} via pixi...")
         manifest_path = self.get_pixi_manifest_path(pandrator_path, env_name)

--- a/pandrator_installer/workflows.py
+++ b/pandrator_installer/workflows.py
@@ -732,6 +732,9 @@ class WorkflowMixin:
 
             shared_pixi_path = self.get_pixi_executable(pandrator_base_path)
 
+            self.reporter.status("Synchronizing Pandrator runtime environment...")
+            self.sync_project_runtime(pandrator_base_path, pandrator_repo_path)
+
             self.reporter.status("Backing up local state database...")
             backup_paths = self.backup_state_database(pandrator_repo_path)
             if backup_paths:

--- a/tests/test_installer_lifecycle.py
+++ b/tests/test_installer_lifecycle.py
@@ -10,13 +10,23 @@ from unittest import mock
 from pathlib import Path
 
 from pandrator_installer.cli import main as launcher_main, parse_launcher_cli_args, run_headless_install_from_cli
-from pandrator_installer.lifecycle import SERVICE_HEALTH_URLS, _owned_service_processes, _runtime_specs, main
+from pandrator_installer.lifecycle import SERVICE_HEALTH_URLS, _owned_service_processes, _runtime_python, _runtime_specs, main
 from pandrator_installer.models import WorkspacePaths, normalize_password_scope
 from pandrator_installer.supervisor import ProcessSupervisor
 from pandrator_installer.update import verify_release_manifest
 
 
 class InstallerLifecycleTests(unittest.TestCase):
+    def test_runtime_uses_the_synchronized_project_pixi_interpreter(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            paths = WorkspacePaths.from_value(workspace)
+            python = paths.pandrator_repo / ".pixi" / "envs" / "default" / "python.exe"
+            python.parent.mkdir(parents=True)
+            python.touch()
+
+            with mock.patch("pandrator_installer.lifecycle.is_windows", return_value=True):
+                self.assertEqual(_runtime_python(paths), python)
+
     def invoke(self, arguments):
         output = io.StringIO()
         error = io.StringIO()

--- a/tests/test_installer_update_migrations.py
+++ b/tests/test_installer_update_migrations.py
@@ -13,6 +13,34 @@ from pandrator_installer.service import HeadlessInstaller
 
 
 class InstallerUpdateMigrationTests(unittest.TestCase):
+    def test_update_runtime_sync_reinstalls_the_project_default_environment(self):
+        with tempfile.TemporaryDirectory() as install_root:
+            project = os.path.join(install_root, "Pandrator")
+            os.makedirs(project)
+            manifest = os.path.join(project, "pixi.toml")
+            with open(manifest, "w", encoding="utf-8") as handle:
+                handle.write("[workspace]\nname = \"pandrator\"\n")
+            database = os.path.join(install_root, "pandrator.sqlite3")
+            with open(database, "wb") as handle:
+                handle.write(b"user-data")
+            installer = HeadlessInstaller(working_dir=os.path.dirname(install_root))
+
+            with patch.object(installer, "run_pixi_command") as run_pixi:
+                installer.sync_project_runtime(install_root, project)
+                installer.sync_project_runtime(install_root, project)
+
+            self.assertEqual(run_pixi.call_count, 2)
+            self.assertEqual(
+                run_pixi.call_args.args,
+                (
+                    install_root,
+                    ["reinstall", "--locked", "--manifest-path", manifest],
+                ),
+            )
+            self.assertEqual(run_pixi.call_args.kwargs["cwd"], project)
+            with open(database, "rb") as handle:
+                self.assertEqual(handle.read(), b"user-data")
+
     def test_legacy_rvc_package_enables_service_migration(self):
         with tempfile.TemporaryDirectory() as install_root:
             site_packages = os.path.join(


### PR DESCRIPTION
## Summary

Ensure Pandrator’s updater synchronizes the project-default Pixi environment
after updating the repository.

## Problem

The legacy updater refreshed the source tree and synchronized only its private
installer environment. However, the launcher prefers the repository’s default
Pixi interpreter when it exists:

`Pandrator/Pandrator/.pixi/envs/default/python.exe`

That environment could therefore remain stale or partially materialized after
an update, causing declared runtime dependencies to be unavailable even though
the update itself appeared successful.

## Symptoms

After an update, Pandrator could fail with successive import errors such as:

- `No module named 'requests'`
- `No module named 'pydub'`
- `No module named 'PIL'`

These dependencies were already declared by the project. Running `pixi add`
appeared to repair them only because it forced Pixi to re-materialize the
environment.

## Changes

- Add `sync_project_runtime()` to run:

  `pixi reinstall --locked --manifest-path <project pixi.toml>`

- Invoke project-runtime synchronization after repository update and before
  later update/restart work.
- Keep the fix dependency-agnostic so future declared dependencies are
  installed automatically.
- Use `--locked` so updater runs cannot rewrite the checked-in release lock.
- Add regression coverage for:
  - project-default environment synchronization;
  - repeated/idempotent updates;
  - launcher interpreter selection;
  - preservation of user database data.

## Validation

- Installer update/lifecycle/dependency tests: `47 passed`
- Installer architecture tests: `77 passed`, `1 skipped`
- Python compilation passed
- `git diff --check` passed