### PR TITLE
chore: refresh generated API contract

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -30,7 +30,7 @@
             "type": "string"
           },
           "application_version": {
-            "default": "0.48.0.dev0",
+            "default": "0.6.6",
             "title": "Application Version",
             "type": "string"
           },

--- a/web/src/lib/api.generated.ts
+++ b/web/src/lib/api.generated.ts
@@ -2030,7 +2030,7 @@ export interface components {
             api_version?: string;
             /**
              * Application Version
-             * @default 0.48.0.dev0
+             * @default 0.6.6
              */
             application_version?: string;
             /** Canonical Origin */


### PR DESCRIPTION
## Summary

Regenerate the checked-in API contract files for the current application
version.

## Problem

`main` declares Pandrator version `0.6.6`, but the generated API contract still
contains the previous default version `0.48.0.dev0`.

This causes the `Check generated API contract` CI step to fail on an otherwise
clean checkout.

## Changes

- Regenerate `openapi.json`
- Regenerate `web/src/lib/api.generated.ts`

The only generated change is:

`0.48.0.dev0` → `0.6.6`

## Validation

- `python scripts/generate_web_contract.py`
- `npm --prefix web run generate-api`
- `git diff --check`
- Confirmed the same mismatch occurs on an untouched `upstream/main` checkout