### PR TITLE
Fix launcher and tray icons

### DIFF
--- a/pandrator_installer/gui/main_window.py
+++ b/pandrator_installer/gui/main_window.py
@@ -63,6 +63,7 @@ from .support import (
     QtLogEmitter,
     QtLogHandler,
     ToggleSwitch,
+    load_launcher_icon,
 )
 
 
@@ -166,6 +167,11 @@ class PandratorInstaller(
 
         # Set up the main window
         self.setWindowTitle("Pandrator Installer & Launcher")
+        launcher_icon = load_launcher_icon()
+        if not launcher_icon.isNull():
+            self.setWindowIcon(launcher_icon)
+        else:
+            logging.warning("Pandrator launcher icon could not be loaded.")
 
         # Full-width backend cards remain readable at ordinary laptop resolutions.
         screen_size = QApplication.primaryScreen().availableGeometry().size()
@@ -266,7 +272,15 @@ class PandratorInstaller(
             logging.info("System tray is unavailable; browser and launcher controls remain active.")
             return
 
-        self.tray_icon = QSystemTrayIcon(self.windowIcon(), self)
+        tray_icon = self.windowIcon()
+        if tray_icon.isNull():
+            self.tray_icon = None
+            logging.warning(
+                "System tray integration is disabled because no launcher icon is available."
+            )
+            return
+
+        self.tray_icon = QSystemTrayIcon(tray_icon, self)
         menu = QMenu(self)
         show_action = QAction("Show Pandrator Launcher", self)
         show_action.triggered.connect(self.restore_from_tray)

--- a/pandrator_installer/gui/support.py
+++ b/pandrator_installer/gui/support.py
@@ -1,7 +1,9 @@
 """Qt workers, logging adapters, and small dialogs used by the installer GUI."""
 
 import logging
+import sys
 import traceback
+from pathlib import Path
 
 from PyQt6.QtCore import QByteArray, QObject, QSize, QThread, Qt, QUrl, pyqtSignal
 from PyQt6.QtGui import QColor, QDesktopServices, QIcon, QPainter, QPen, QPixmap
@@ -24,6 +26,34 @@ GITHUB_MARK_SVG = b"""
 </svg>
 """
 
+
+def load_launcher_icon():
+    """Load the packaged or source-tree Pandrator application icon."""
+    candidate_roots = []
+
+    bundle_root = str(getattr(sys, "_MEIPASS", "") or "")
+    if bundle_root:
+        candidate_roots.append(Path(bundle_root))
+
+    candidate_roots.append(Path(__file__).resolve().parents[2])
+
+    seen = set()
+    for root in candidate_roots:
+        normalized_root = root.resolve()
+        if normalized_root in seen:
+            continue
+        seen.add(normalized_root)
+
+        for filename in ("pandrator.ico", "pandrator.png"):
+            icon_path = normalized_root / filename
+            if not icon_path.is_file():
+                continue
+
+            icon = QIcon(str(icon_path))
+            if not icon.isNull():
+                return icon
+
+    return QIcon()
 
 def create_github_icon(size=18):
     renderer = QSvgRenderer(QByteArray(GITHUB_MARK_SVG))

--- a/pandrator_installer_launcher.spec
+++ b/pandrator_installer_launcher.spec
@@ -18,7 +18,9 @@ a = Analysis(
     ['pandrator_installer_launcher.py'],
     pathex=[],
     binaries=[(str(library), '.') for library in runtime_libraries],
-    datas=[],
+    datas=[
+        ('pandrator.ico', '.'),
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/tests/test_installer_launcher_chatterbox.py
+++ b/tests/test_installer_launcher_chatterbox.py
@@ -2,12 +2,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 import json
 import os
+import shutil
+import sys
 import tempfile
+from pathlib import Path
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication, QCheckBox, QDialog, QLabel, QScrollArea, QSizePolicy
 from pandrator_installer_launcher import PandratorInstaller
 from pandrator_installer.gui.main_window import OwnerPasswordDialog, QwenConfigDialog
-from pandrator_installer.gui.support import ToggleSwitch
+from pandrator_installer.gui.support import ToggleSwitch, load_launcher_icon
 
 
 class TestInstallerLauncherChatterbox(unittest.TestCase):
@@ -357,6 +360,31 @@ class TestInstallerLauncherChatterbox(unittest.TestCase):
             # Since GPU support is True, use_cpu should be False
             self.assertFalse(called_kwargs["use_cpu"])
 
+
+    def test_launcher_window_uses_pandrator_icon(self):
+        installer = PandratorInstaller(headless=True)
+
+        self.assertFalse(installer.windowIcon().isNull())
+
+    def test_launcher_icon_loads_from_pyinstaller_bundle(self):
+        repo_root = Path(__file__).resolve().parents[1]
+
+        with tempfile.TemporaryDirectory() as bundle_root:
+            bundled_icon = Path(bundle_root) / "pandrator.png"
+            shutil.copy2(repo_root / "pandrator.png", bundled_icon)
+
+            with patch.object(sys, "_MEIPASS", bundle_root, create=True):
+                icon = load_launcher_icon()
+
+        self.assertFalse(icon.isNull())
+
+    def test_windows_installer_spec_bundles_runtime_icon(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        spec_text = (repo_root / "pandrator_installer_launcher.spec").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("('pandrator.ico', '.')", spec_text)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
﻿## Summary

- Load the existing Pandrator application icon for the launcher window.
- Reuse the same non-null icon for the system tray.
- Disable tray integration cleanly when no icon can be resolved.
- Bundle `pandrator.ico` as Windows runtime data in the PyInstaller build.
- Add regression coverage for source-tree loading, PyInstaller bundle loading, and Windows packaging.

## Root cause

The launcher never assigned a window icon. `setup_system_tray()` then constructed `QSystemTrayIcon` from the empty `self.windowIcon()`, producing:

`QSystemTrayIcon::setVisible: No Icon set`

The Windows PyInstaller spec also used `pandrator.ico` only as the executable icon and did not include it as a runtime data file.

## Validation

- Manual launcher test confirmed the window and tray icons now appear.
- The Qt warning no longer appears.
- `git diff --check`
- `python -m unittest tests.test_installer_architecture tests.test_installer_launcher_chatterbox`
  - `Ran 96 tests ... OK (skipped=1)`
