### PR TITLE
fix: preserve generation drawer height during regeneration

### DIFF
--- a/web/src/lib/GenerationDrawer.svelte
+++ b/web/src/lib/GenerationDrawer.svelte
@@ -455,9 +455,13 @@
     }
   }
 
+  function expandIfCollapsed() {
+    if (mode === 'collapsed') mode = 'half';
+  }
+
   function applyLoadResult(result: GenerationLoadResult) {
     selectedRunId = result.selectedRunId;
-    if (result.shouldExpand) mode = 'half';
+    if (result.shouldExpand) expandIfCollapsed();
   }
 
   async function patchSegment(
@@ -559,7 +563,7 @@
   ) {
     if (operation === 'rvc' && !rvcModel) {
       showRvc = true;
-      mode = 'half';
+      expandIfCollapsed();
       error = 'Choose an RVC model before converting audio.';
       return;
     }
@@ -589,7 +593,7 @@
       );
       generationStore.upsertRun(started);
       selectedRunId = started.id;
-      mode = 'half';
+      expandIfCollapsed();
       await load();
       void reconcileStartedRun(started.id);
     } catch (caught) {
@@ -965,6 +969,7 @@
 
 {#if payload.total > 0 || run}
   <aside
+    data-generation-layout={mode}
     class:full={mode === 'full'}
     class:half={mode === 'half'}
     class="generation-drawer fixed inset-x-3 bottom-3 z-50 overflow-hidden rounded-2xl md:left-[calc(var(--sidebar-offset,5rem)+.35rem)] md:right-[.35rem]"

--- a/web/tests/workspace.spec.ts
+++ b/web/tests/workspace.spec.ts
@@ -736,6 +736,145 @@ test('generation segment search and replace preserves partial words and saves ev
   ]);
 });
 
+test('generation drawer layout survives segment regeneration refreshes', async ({
+  page
+}) => {
+  let phase: 'completed' | 'running' = 'completed';
+  let revision = 0;
+  let failNextRegeneration = false;
+  const runId = 'layout-run';
+  await page.route('**/api/v1/events?after=*', (route) => route.abort());
+  await signIn(page);
+  const sessionId = await createGenerationPlan(page, [
+    { text: 'Synthetic generation segment.' }
+  ]);
+  const run = () => ({
+    id: runId,
+    session_id: sessionId,
+    plan_revision_id: 'layout-plan',
+    sequence_number: 1,
+    operation: 'regenerate',
+    label: 'Layout test run',
+    job_id: 'layout-job',
+    status: phase,
+    progress: phase === 'completed' ? 1 : 0.5
+  });
+  await page.route(
+    `**/api/v1/sessions/${sessionId}/generation-runs`,
+    async (route) => {
+      if (route.request().method() === 'POST') {
+        if (failNextRegeneration) {
+          failNextRegeneration = false;
+          await route.fulfill({
+            status: 500,
+            contentType: 'application/json',
+            body: JSON.stringify({ detail: 'Synthetic regeneration failure.' })
+          });
+          return;
+        }
+        phase = 'running';
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(run())
+        });
+        setTimeout(() => {
+          revision += 1;
+          phase = 'completed';
+        }, 100);
+        return;
+      }
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [run()] })
+      });
+    }
+  );
+  await page.route(
+    `**/api/v1/sessions/${sessionId}/output-assemblies/latest`,
+    (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ item: null })
+      })
+  );
+  await page.route(
+    `**/api/v1/sessions/${sessionId}/generation-segments?*`,
+    (route) =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [
+            {
+              id: 'synthetic-segment',
+              ordinal: 0,
+              node_kind: 'paragraph',
+              paragraph_break_after: false,
+              text: `Synthetic generation segment revision ${revision}.`,
+              optimized_text: null,
+              speech_plan: {},
+              optimization_status: 'not_requested',
+              optimization_reviewed: false,
+              marked: false,
+              removed: false,
+              status: 'completed',
+              revision,
+              takes: []
+            }
+          ],
+          total: 1,
+          next_cursor: null,
+          plan_revision_id: 'layout-plan'
+        })
+      })
+  );
+
+  await page.goto(`/sessions/${sessionId}`);
+  const drawer = page.locator('[data-generation-layout]');
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'collapsed');
+  await page.getByRole('button', { name: 'Generation', exact: true }).click();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'half');
+  await page.getByRole('button', { name: 'Use full height' }).click();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'full');
+
+  const regenerate = page.getByRole('button', {
+    name: 'Regenerate segment 1'
+  });
+  const segmentText = page.locator(
+    'tr[data-segment-id="synthetic-segment"] textarea'
+  );
+  await regenerate.click();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'full');
+  await expect(segmentText).toHaveValue(
+    'Synthetic generation segment revision 1.',
+    { timeout: 10_000 }
+  );
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'full');
+
+  await page.getByRole('button', { name: 'Use half height' }).click();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'half');
+  await regenerate.click();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'half');
+  await expect(segmentText).toHaveValue(
+    'Synthetic generation segment revision 2.',
+    { timeout: 10_000 }
+  );
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'half');
+
+  await page.getByRole('button', { name: 'Use full height' }).click();
+  failNextRegeneration = true;
+  await regenerate.click();
+  expect(failNextRegeneration).toBeFalsy();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'full');
+
+  const unrelatedSessionId = await createGenerationPlan(page, [
+    { text: 'Unrelated synthetic segment.' }
+  ]);
+  await page.goto(`/sessions/${unrelatedSessionId}`);
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'collapsed');
+  await page.getByRole('button', { name: 'Generation', exact: true }).click();
+  await expect(drawer).toHaveAttribute('data-generation-layout', 'half');
+});
+
 test('generated segments return to the current filtered page after repeated regeneration', async ({
   page
 }) => {


### PR DESCRIPTION
## Summary

Preserve the user-selected generation drawer layout when regenerating segments.

## Problem

The generation drawer owns local `mode` state, but the shared regeneration
`start()` path unconditionally reset that state to `half`. The generation-store
refresh callback could also downgrade a full-height drawer when auto-expanding
a refreshed run.

As a result, regenerating a segment while using full height caused the drawer
to revert to half height.

## Fix

- Add `expandIfCollapsed()` so automatic expansion only opens a collapsed
  drawer.
- Preserve both `half` and `full` modes during regeneration and refreshes.
- Add a semantic `data-generation-layout` attribute for browser assertions.

## Behavior

- Full height remains full during successful and failed regenerations.
- Half height remains half.
- Collapsed drawers may still auto-expand where existing behavior requires it.
- Unrelated session navigation keeps the existing per-session local-state
  behavior.

## Validation

- Web build passed.
- `svelte-check` passed with 0 errors and 0 warnings.
- Full Chromium workspace suite passed: 15 passed, 1 Windows-skipped visual test.
- `git diff --check` passed.

## Scope

Frontend-only change. No backend, API, or migration changes.