### PR TITLE
fix: reconcile terminal generation cancellation state

### DIFF
--- a/pandrator/web/api.py
+++ b/pandrator/web/api.py
@@ -39,6 +39,7 @@ def create_app(
         capability_ttl_seconds=capability_ttl_seconds,
         public_origin=public_origin,
     )
+    services.jobs.reconcile()
     static_dir = Path(__file__).with_name("static")
     app = Flask(
         __name__,

--- a/pandrator/web/jobs.py
+++ b/pandrator/web/jobs.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from .credentials import SecretRedactor
 from .database import Database
-from .models import Job, JobEvent, ResourceClaim, utcnow
+from .models import GenerationRun, Job, JobEvent, ResourceClaim, utcnow
 
 JobHandler = Callable[[dict[str, Any], Callable[[float, str | None], None], threading.Event], dict[str, Any] | None]
 
@@ -39,6 +39,13 @@ class JobQueue:
         "document_id",
         "model_id",
     )
+    GENERATION_ACTIVE_STATUSES = {
+        "queued",
+        "running",
+        "pausing",
+        "pause_requested",
+        "cancel_requested",
+    }
 
     def __init__(
         self,
@@ -233,6 +240,70 @@ class JobQueue:
             session.execute(
                 delete(ResourceClaim).where(ResourceClaim.job_id.in_(terminal_job_ids))
             )
+        self._reconcile_generation_runs_locked(session)
+
+    def _reconcile_generation_runs_locked(self, session, session_id: str | None = None) -> None:
+        """Keep generation runs terminal when their owning job is terminal or gone."""
+        runs = list(
+            session.scalars(
+                select(GenerationRun).where(
+                    GenerationRun.status.in_(self.GENERATION_ACTIVE_STATUSES),
+                    *([GenerationRun.session_id == session_id] if session_id else []),
+                )
+            ).all()
+        )
+        for run in runs:
+            job = session.get(Job, run.job_id) if run.job_id else None
+            if job is None:
+                if run.status == "cancel_requested":
+                    run.status = "canceled"
+                    run.cancel_requested = False
+                    run.updated_at = utcnow()
+                continue
+            payload = job.payload_json if isinstance(job.payload_json, dict) else {}
+            if (
+                job.kind != "generation.run"
+                or job.session_id != run.session_id
+                or str(payload.get("generation_run_id") or "") != run.id
+            ):
+                continue
+            if job.status == "failed":
+                run.status = "failed"
+                run.cancel_requested = False
+            elif job.status in {"canceled", "interrupted"}:
+                run.status = "canceled"
+                run.cancel_requested = False
+            else:
+                continue
+            run.updated_at = utcnow()
+
+    def reconcile(self) -> None:
+        """Repair expired jobs and any generation runs left behind by terminal jobs."""
+        with self.database.immediate_session() as session:
+            self._reconcile_stale_locked(session)
+
+    def reconcile_session(self, session_id: str) -> None:
+        """Repair terminal generation jobs for one session without touching others."""
+        with self.database.session() as session:
+            candidate = session.scalar(
+                select(GenerationRun.id)
+                .join(Job, GenerationRun.job_id == Job.id, isouter=True)
+                .where(
+                    GenerationRun.session_id == session_id,
+                    GenerationRun.status.in_(self.GENERATION_ACTIVE_STATUSES),
+                    or_(
+                        and_(
+                            GenerationRun.job_id.is_(None),
+                            GenerationRun.status == "cancel_requested",
+                        ),
+                        Job.status.in_(("failed", "canceled", "interrupted")),
+                    ),
+                ).limit(1)
+            )
+        if candidate is None:
+            return
+        with self.database.immediate_session() as session:
+            self._reconcile_generation_runs_locked(session, session_id)
 
     def _reconcile_stale(self) -> None:
         """Serialize the uncommon stale-job transition without locking normal reads."""
@@ -601,19 +672,13 @@ class JobQueue:
             job.finished_at = utcnow()
             event_type = "job.canceled"
         elif job.status in {"running", "cancel_requested"}:
-            # Cancellation is a terminal state immediately. The worker's
-            # monitor notices it independently of progress callbacks and
-            # prevents any later result from replacing this state.
-            self._event(session, job.id, "job.cancel_requested")
-            job.status = "canceled"
-            job.finished_at = utcnow()
-            job.lease_owner = None
-            job.lease_expires_at = None
-            event_type = "job.canceled"
+            job.status = "cancel_requested"
+            event_type = "job.cancel_requested"
         else:
             event_type = "job.cancel_ignored"
         job.updated_at = utcnow()
         self._event(session, job.id, event_type)
+        self._reconcile_generation_runs_locked(session)
         session.flush()
         return job
 
@@ -680,6 +745,8 @@ class JobQueue:
                 "job.retry_scheduled" if retry else "job.failed",
                 {"code": safe_code, "message": safe_message, "trace": safe_trace},
             )
+            if not retry:
+                self._reconcile_generation_runs_locked(session)
             return True
 
     def cancel_owned(
@@ -691,7 +758,12 @@ class JobQueue:
     ) -> bool:
         with self.database.immediate_session() as session:
             job = session.get(Job, job_id)
-            if not self._owns_lease(job, worker_id, lease_generation):
+            if not self._owns_lease(
+                job, worker_id, lease_generation, require_running=False
+            ) or (
+                job.lease_expires_at is not None
+                and job.lease_expires_at.replace(tzinfo=utcnow().tzinfo) <= utcnow()
+            ) or job.status not in {"running", "cancel_requested"}:
                 return False
             job.status = "canceled"
             job.lease_owner = None
@@ -699,6 +771,7 @@ class JobQueue:
             job.finished_at = utcnow()
             job.updated_at = job.finished_at
             self._event(session, job.id, "job.canceled")
+            self._reconcile_generation_runs_locked(session)
             return True
 
     def events_after(self, event_id: int = 0, limit: int = 250) -> list[JobEvent]:

--- a/pandrator/web/workspace.py
+++ b/pandrator/web/workspace.py
@@ -1769,6 +1769,7 @@ class GenerationService:
         generation_run_id: str | None = None,
         operation: str = "generate",
     ) -> dict[str, Any]:
+        self.jobs.reconcile_session(session_id)
         requested_segment_ids = [str(value) for value in (segment_ids or []) if str(value)]
         reused_run = False
         resolved_for_new: tuple[dict[str, Any], str] | None = None
@@ -1928,7 +1929,7 @@ class GenerationService:
         return {"id": run_id, "job_id": job.id, "status": "queued"}
 
     def cancel(self, run_id: str) -> dict[str, Any]:
-        with self.database.session() as session:
+        with self.database.immediate_session() as session:
             run = session.get(GenerationRun, run_id)
             if run is None:
                 raise KeyError(run_id)
@@ -1936,12 +1937,14 @@ class GenerationService:
             run.status = "cancel_requested"
             run.updated_at = utcnow()
             job_id = run.job_id
-        if job_id:
-            try:
-                self.jobs.request_cancel(job_id)
-            except KeyError:
-                pass
-        return {"id": run_id, "job_id": job_id, "status": "cancel_requested"}
+            if job_id:
+                try:
+                    self.jobs.request_cancel_in_session(session, job_id)
+                except KeyError:
+                    self.jobs._reconcile_generation_runs_locked(session)
+            else:
+                self.jobs._reconcile_generation_runs_locked(session)
+            return {"id": run.id, "job_id": job_id, "status": run.status}
 
     @staticmethod
     def _run_label(run: GenerationRun) -> str:
@@ -2009,6 +2012,7 @@ class GenerationService:
         }
 
     def list_runs(self, session_id: str) -> list[dict[str, Any]]:
+        self.jobs.reconcile_session(session_id)
         with self.database.session() as session:
             runs = list(
                 session.scalars(
@@ -2020,6 +2024,7 @@ class GenerationService:
             return [self._run_payload(session, run) for run in runs]
 
     def latest_run(self, session_id: str) -> dict[str, Any] | None:
+        self.jobs.reconcile_session(session_id)
         with self.database.session() as session:
             run = session.scalar(
                 select(GenerationRun)
@@ -2029,6 +2034,14 @@ class GenerationService:
             return self._run_payload(session, run)
 
     def delete_run(self, run_id: str) -> dict[str, Any]:
+        with self.database.session() as session:
+            run = session.get(GenerationRun, run_id)
+            if run is not None:
+                session_id = run.session_id
+            else:
+                session_id = None
+        if session_id:
+            self.jobs.reconcile_session(session_id)
         paths_to_remove: list[Path] = []
         with self.database.session() as session:
             run = session.get(GenerationRun, run_id)

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -6,7 +6,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
-from contextlib import closing
+from contextlib import closing, contextmanager
 from datetime import timedelta
 from pathlib import Path
 from unittest import mock
@@ -29,6 +29,7 @@ from pandrator.web.models import (
     Artifact,
     GenerationPlan,
     GenerationPlanRevision,
+    GenerationRun,
     GenerationSegment,
     Job,
     JobEvent,
@@ -480,6 +481,48 @@ class DurableJobTests(unittest.TestCase):
         self.database.dispose()
         self.temporary.cleanup()
 
+    def _generation_run(self, *, job_status="queued", run_status="queued", job_kind="generation.run", payload_run_id=None, job_session_id=None):
+        """Create one linked generation run with deliberately controllable job data."""
+        workspace = self.sessions.create("Generation reconciliation")
+        with self.database.session() as session:
+            plan = GenerationPlan(session_id=workspace.id)
+            session.add(plan)
+            session.flush()
+            revision = GenerationPlanRevision(
+                plan_id=plan.id,
+                revision_number=1,
+                content_hash=f"reconciliation-{workspace.id}",
+            )
+            session.add(revision)
+            session.flush()
+            plan.active_revision_id = revision.id
+            revision_id = revision.id
+        job = self.queue.enqueue(
+            job_kind,
+            {"generation_run_id": payload_run_id or "pending"},
+            session_id=job_session_id or workspace.id,
+        )
+        with self.database.session() as session:
+            run = GenerationRun(
+                session_id=workspace.id,
+                plan_revision_id=revision_id,
+                sequence_number=1,
+                job_id=job.id,
+                status=run_status,
+                cancel_requested=run_status == "cancel_requested",
+            )
+            session.add(run)
+            session.flush()
+            job = session.get(Job, job.id)
+            job.status = job_status
+            job.payload_json = {"generation_run_id": payload_run_id or run.id}
+            return workspace, run.id, job.id
+
+    def _run_state(self, run_id):
+        with self.database.session() as session:
+            run = session.get(GenerationRun, run_id)
+            return run.status, run.cancel_requested, run.updated_at
+
     def test_worker_completes_job_and_records_events(self):
         job = self.queue.enqueue("noop", {"echo": "ready"})
         worker = Worker(self.queue, "worker-one", {"noop": noop_handler})
@@ -508,14 +551,14 @@ class DurableJobTests(unittest.TestCase):
         self.assertEqual(canceled.status, "canceled")
         self.assertIsNone(self.queue.claim("worker"))
 
-    def test_canceling_running_job_is_immediately_terminal(self):
+    def test_canceling_running_job_waits_for_the_lease_owner(self):
         job = self.queue.enqueue("noop")
         claimed = self.queue.claim("worker")
         self.assertEqual(job.id, claimed.id)
 
         canceled = self.queue.request_cancel(job.id)
 
-        self.assertEqual("canceled", canceled.status)
+        self.assertEqual("cancel_requested", canceled.status)
         self.assertTrue(
             self.queue.should_cancel(
                 job.id,
@@ -523,6 +566,17 @@ class DurableJobTests(unittest.TestCase):
                 lease_generation=claimed.lease_generation,
             )
         )
+        self.assertFalse(
+            self.queue.cancel_owned(
+                job.id, "another-worker", lease_generation=claimed.lease_generation
+            )
+        )
+        self.assertTrue(
+            self.queue.cancel_owned(
+                job.id, "worker", lease_generation=claimed.lease_generation
+            )
+        )
+        self.assertEqual("canceled", self.queue.get(job.id).status)
         with self.assertRaises(RuntimeError):
             self.queue.complete(
                 job.id,
@@ -542,6 +596,170 @@ class DurableJobTests(unittest.TestCase):
 
         self.assertEqual("failed", reconciled.status)
         self.assertEqual("worker_lease_expired", reconciled.error_code)
+
+    def test_clean_job_get_and_list_do_not_take_an_immediate_session(self):
+        job = self.queue.enqueue("noop")
+        original_immediate = self.database.immediate_session
+        immediate_calls = []
+
+        def record_immediate():
+            immediate_calls.append(True)
+            return original_immediate()
+
+        with mock.patch.object(
+            self.database, "immediate_session", side_effect=record_immediate
+        ):
+            self.assertEqual(job.id, self.queue.get(job.id).id)
+            self.assertEqual([job.id], [item.id for item in self.queue.list()])
+
+        self.assertEqual([], immediate_calls)
+
+    def test_stale_job_probe_locks_and_reconciles_the_candidate(self):
+        job = self.queue.enqueue("noop", max_attempts=1)
+        claimed = self.queue.claim("worker", lease_seconds=5)
+        with self.database.session() as session:
+            session.get(Job, job.id).lease_expires_at = utcnow() - timedelta(seconds=1)
+        original_immediate = self.database.immediate_session
+        immediate_calls = []
+
+        def record_immediate():
+            immediate_calls.append(True)
+            return original_immediate()
+
+        with mock.patch.object(
+            self.database, "immediate_session", side_effect=record_immediate
+        ):
+            reconciled = self.queue.get(job.id)
+
+        self.assertEqual([True], immediate_calls)
+        self.assertEqual("failed", reconciled.status)
+        self.assertEqual("worker_lease_expired", reconciled.error_code)
+
+    def test_stale_job_candidate_is_revalidated_inside_the_write_transaction(self):
+        job = self.queue.enqueue("noop", max_attempts=1)
+        self.queue.claim("worker", lease_seconds=5)
+        with self.database.session() as session:
+            session.get(Job, job.id).lease_expires_at = utcnow() - timedelta(seconds=1)
+        original_immediate = self.database.immediate_session
+        immediate_calls = []
+
+        @contextmanager
+        def candidate_changed_before_lock():
+            with original_immediate() as session:
+                immediate_calls.append(True)
+                current = session.get(Job, job.id)
+                current.status = "succeeded"
+                current.lease_owner = None
+                current.lease_expires_at = None
+                yield session
+
+        with mock.patch.object(
+            self.database,
+            "immediate_session",
+            side_effect=candidate_changed_before_lock,
+        ):
+            reconciled = self.queue.get(job.id)
+
+        self.assertEqual([True], immediate_calls)
+        self.assertEqual("succeeded", reconciled.status)
+        self.assertIsNone(reconciled.error_code)
+
+    def test_startup_reconciliation_terminalizes_stale_generation_runs_only(self):
+        _, failed_id, _ = self._generation_run(job_status="failed", run_status="running")
+        _, canceled_id, _ = self._generation_run(job_status="canceled", run_status="cancel_requested")
+        orphan_workspace, orphan_id, _ = self._generation_run(run_status="cancel_requested")
+        with self.database.session() as session:
+            orphan = session.get(GenerationRun, orphan_id)
+            orphan.job_id = None
+        _, queued_id, _ = self._generation_run(run_status="queued")
+        _, running_id, running_job_id = self._generation_run(job_status="running", run_status="running")
+        with self.database.session() as session:
+            running_job = session.get(Job, running_job_id)
+            running_job.lease_owner = "healthy-worker"
+            running_job.lease_expires_at = utcnow() + timedelta(minutes=5)
+        before = {
+            queued_id: self._run_state(queued_id),
+            running_id: self._run_state(running_id),
+        }
+
+        self.queue.reconcile()
+
+        self.assertEqual(("failed", False), self._run_state(failed_id)[:2])
+        self.assertEqual(("canceled", False), self._run_state(canceled_id)[:2])
+        self.assertEqual(("canceled", False), self._run_state(orphan_id)[:2])
+        self.assertEqual(before[queued_id], self._run_state(queued_id))
+        self.assertEqual(before[running_id], self._run_state(running_id))
+
+    def test_startup_reconciliation_is_idempotent_for_terminal_and_orphaned_runs(self):
+        _, failed_id, _ = self._generation_run(job_status="failed", run_status="running")
+        _, canceled_id, _ = self._generation_run(job_status="canceled", run_status="cancel_requested")
+        _, orphan_id, _ = self._generation_run(run_status="cancel_requested")
+        with self.database.session() as session:
+            session.get(GenerationRun, orphan_id).job_id = None
+
+        self.queue.reconcile()
+        first_pass = {run_id: self._run_state(run_id) for run_id in (failed_id, canceled_id, orphan_id)}
+        self.queue.reconcile()
+
+        self.assertEqual(first_pass, {run_id: self._run_state(run_id) for run_id in first_pass})
+
+    def test_startup_reconciliation_requires_a_safe_generation_job_link(self):
+        _, payload_mismatch_id, _ = self._generation_run(job_status="failed", run_status="running", payload_run_id="other-run")
+        foreign_workspace = self.sessions.create("Foreign generation session")
+        _, session_mismatch_id, _ = self._generation_run(job_status="canceled", run_status="running", job_session_id=foreign_workspace.id)
+        _, non_generation_id, _ = self._generation_run(job_status="failed", run_status="running", job_kind="source.clean")
+        _, terminal_id, _ = self._generation_run(job_status="failed", run_status="canceled")
+        before = {run_id: self._run_state(run_id) for run_id in (payload_mismatch_id, session_mismatch_id, non_generation_id, terminal_id)}
+
+        self.queue.reconcile()
+
+        self.assertEqual(before, {run_id: self._run_state(run_id) for run_id in before})
+
+    def test_session_reconciliation_is_scoped_and_locks_only_stale_candidates(self):
+        session_a = self.sessions.create("Clean session")
+        _, stale_b_id, _ = self._generation_run(job_status="failed", run_status="running")
+        original_immediate = self.database.immediate_session
+        immediate_calls = []
+
+        def record_immediate():
+            immediate_calls.append(True)
+            return original_immediate()
+
+        with mock.patch.object(self.database, "immediate_session", side_effect=record_immediate):
+            self.queue.reconcile_session(session_a.id)
+        self.assertEqual([], immediate_calls)
+        self.assertEqual("running", self._run_state(stale_b_id)[0])
+
+        workspace_a, stale_a_id, _ = self._generation_run(job_status="failed", run_status="running")
+        locked_sessions = []
+        original_locked = self.queue._reconcile_generation_runs_locked
+
+        def record_locked(session, session_id=None):
+            locked_sessions.append(session_id)
+            return original_locked(session, session_id)
+
+        with mock.patch.object(self.database, "immediate_session", side_effect=record_immediate), mock.patch.object(self.queue, "_reconcile_generation_runs_locked", side_effect=record_locked):
+            self.queue.reconcile_session(workspace_a.id)
+        self.assertEqual([workspace_a.id], locked_sessions)
+        self.assertEqual([True], immediate_calls)
+        self.assertEqual(("failed", False), self._run_state(stale_a_id)[:2])
+        self.assertEqual("running", self._run_state(stale_b_id)[0])
+
+    def test_session_reconciliation_skips_a_harmless_unlinked_queued_run_without_locking(self):
+        workspace, run_id, _ = self._generation_run(run_status="queued")
+        with self.database.session() as session:
+            session.get(GenerationRun, run_id).job_id = None
+        original_immediate = self.database.immediate_session
+        immediate_calls = []
+
+        def record_immediate():
+            immediate_calls.append(True)
+            return original_immediate()
+
+        with mock.patch.object(self.database, "immediate_session", side_effect=record_immediate):
+            self.queue.reconcile_session(workspace.id)
+        self.assertEqual([], immediate_calls)
+        self.assertEqual(("queued", False), self._run_state(run_id)[:2])
 
     def test_worker_python_logs_are_available_in_job_timeline(self):
         def logged(_payload, _progress, _cancel_event):

--- a/tests/test_web_parity_workspace.py
+++ b/tests/test_web_parity_workspace.py
@@ -1038,6 +1038,57 @@ class WebParityWorkspaceTests(unittest.TestCase):
         self.assertNotEqual(first["job_id"], retry.get_json()["job_id"])
         self.assertEqual(1, len(self.client.get(f"/api/v1/sessions/{record['id']}/generation-runs").get_json()["items"]))
 
+    def test_terminal_job_reconciles_a_cancel_requested_generation_run(self):
+        record = self.create_session("audiobook")
+        self.client.post(
+            f"/api/v1/sessions/{record['id']}/generation-plan",
+            json={"segments": [{"text": "Synthetic failed segment."}]},
+            headers=self.headers,
+        )
+        started = self.client.post(
+            f"/api/v1/sessions/{record['id']}/generation-runs",
+            json={}, headers=self.headers,
+        ).get_json()
+        with self.app.extensions["pandrator"]["database"].session() as session:
+            run = session.get(GenerationRun, started["id"])
+            job = session.get(Job, started["job_id"])
+            run.status = "cancel_requested"
+            run.cancel_requested = True
+            job.status = "failed"
+
+        canceled = self.client.post(
+            f"/api/v1/generation-runs/{started['id']}/cancel", headers=self.headers
+        )
+        self.assertEqual(202, canceled.status_code, canceled.get_json())
+        self.assertEqual("failed", canceled.get_json()["status"])
+        listed = self.client.get(
+            f"/api/v1/sessions/{record['id']}/generation-runs"
+        ).get_json()["items"]
+        self.assertEqual("failed", listed[0]["status"])
+
+    def test_orphaned_cancel_requested_generation_run_is_canceled(self):
+        record = self.create_session("audiobook")
+        plan = self.client.post(
+            f"/api/v1/sessions/{record['id']}/generation-plan",
+            json={"segments": [{"text": "Synthetic orphaned segment."}]},
+            headers=self.headers,
+        ).get_json()
+        with self.app.extensions["pandrator"]["database"].session() as session:
+            run = GenerationRun(
+                session_id=record["id"], plan_revision_id=plan["active_revision_id"],
+                sequence_number=1, status="cancel_requested", cancel_requested=True,
+                job_id=None,
+            )
+            session.add(run)
+            session.flush()
+            run_id = run.id
+
+        listed = self.client.get(
+            f"/api/v1/sessions/{record['id']}/generation-runs"
+        ).get_json()["items"]
+        self.assertEqual(run_id, listed[0]["id"])
+        self.assertEqual("canceled", listed[0]["status"])
+
     def test_generation_segments_are_scoped_to_the_selected_run_revision(self):
         record = self.create_session("audiobook")
         first_plan = self.client.post(

--- a/web/tests/workspace.spec.ts
+++ b/web/tests/workspace.spec.ts
@@ -641,6 +641,67 @@ test('running generation controls stay on one drawer header row', async ({
   expect(Math.max(...rowCenters) - Math.min(...rowCenters)).toBeLessThan(2);
 });
 
+test('terminal generation recovery clears the active run state after refresh', async ({
+  page
+}) => {
+  await page.route('**/api/v1/events?after=*', (route) => route.abort());
+  await signIn(page);
+  const sessionId = await createGenerationPlan(page, [
+    { text: 'A recovery test generation segment.' }
+  ]);
+  let listReads = 0;
+  let starts = 0;
+  const run = (status: 'cancel_requested' | 'canceled') => ({
+    id: 'recovered-generation-run',
+    session_id: sessionId,
+    plan_revision_id: 'generation-plan',
+    sequence_number: 1,
+    operation: 'generate',
+    label: 'Run 1: recovery test',
+    job_id: 'recovered-generation-job',
+    status,
+    progress: 0.5
+  });
+  await page.route(
+    `**/api/v1/sessions/${sessionId}/generation-runs`,
+    async (route) => {
+      if (route.request().method() === 'POST') {
+        starts += 1;
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ ...run('canceled'), id: 'replacement-run' })
+        });
+        return;
+      }
+      listReads += 1;
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items: [run(listReads === 1 ? 'cancel_requested' : 'canceled')]
+        })
+      });
+    }
+  );
+
+  await page.goto(`/sessions/${sessionId}`);
+  await page.getByRole('button', { name: 'Generation', exact: true }).click();
+  await expect(
+    page.getByRole('progressbar', { name: 'Generation progress' })
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start', exact: true })).toHaveCount(0);
+
+  await page.reload();
+  await page.getByRole('button', { name: 'Generation', exact: true }).click();
+  await expect(
+    page.getByRole('progressbar', { name: 'Generation progress' })
+  ).toHaveCount(0);
+  await expect(page.locator('.run-picker select')).toHaveText(/canceled/);
+  const start = page.getByRole('button', { name: 'Start', exact: true });
+  await expect(start).toBeEnabled();
+  await start.click();
+  await expect.poll(() => starts).toBe(1);
+});
+
 test('generation segments support Ctrl and Shift multi-selection in both review views', async ({
   page
 }) => {


### PR DESCRIPTION
## Summary

Reliably reconcile generation runs when their linked durable job has already
failed, been canceled, expired, or disappeared.

## Problem

A generation run could remain indefinitely in `cancel_requested` after the
underlying worker job had already reached a terminal state. The UI continued to
treat the run as active, blocking regeneration, starting a new run, or deleting
the stale run.

The same cancellation path also needed to preserve orderly worker
acknowledgment for genuinely active jobs.

## Fix

- Propagate terminal durable-job states to linked generation runs.
- Allow only the current valid lease owner to acknowledge a
  `cancel_requested` job as canceled.
- Reconcile orphaned `cancel_requested` runs safely.
- Validate job kind, session, and `generation_run_id` before changing run state.
- Run a global repair pass at startup.
- Use session-scoped, read-first reconciliation during workspace operations.
- Avoid SQLite write locks during clean `JobQueue.get()` and `JobQueue.list()`
  reads.
- Revalidate stale candidates inside the write transaction before mutation.

## State behavior

- Running cancellation remains `cancel_requested` until worker acknowledgment.
- Valid lease-owner acknowledgment changes the job and run to `canceled`.
- Failed generation job changes the active run to `failed`.
- Canceled or interrupted generation job changes the active run to `canceled`.
- Missing job plus `cancel_requested` run changes the run to `canceled`.
- Healthy queued/running jobs remain unchanged.
- Already-terminal runs remain unchanged.
- Mismatched or non-generation jobs cannot alter a generation run.

## Validation

- Durable job and workspace backend suites: `51 passed`
- Focused clean-read/stale-lock tests: `3 passed`
- Python compilation passed
- `git diff --check` passed

A focused Playwright recovery test was added, but Chromium execution on Windows
is currently blocked by a pre-existing upstream CSP line-ending bug reproduced
on clean `upstream/main`. The issue is unrelated to this patch: the server
hashes newline-normalized inline script text while Flask serves CRLF bytes,
causing Chromium to block the SPA bootstrap.

## Scope

No voice-publication, TTS-provider, or unrelated frontend behavior changes.