### PR TITLE
Migrate Windows launcher to authenticated Pandrator Manager

### DIFF
--- a/pandrator_manager/README.md
+++ b/pandrator_manager/README.md
@@ -235,6 +235,20 @@ the
 
 ## Legacy import, releases, and uninstall
 
+### Migrating the retired Qt installer
+
+`PandratorInstaller.exe` builds released before the Manager migration used a
+separate legacy supervisor. Updating its checked-out application source or
+speech components does **not** update that executable, so it cannot provide
+the Manager descriptor and credential handoff required by the current WebUI.
+
+Download and run the current `PandratorManager-...-windows-x86_64.exe` once,
+select the same parent workspace, and use the recovery UI's legacy import
+flow. It records the existing installation conservatively, then subsequent
+launches use the digest-verified Manager launcher in `Pandrator/bin`. Do not
+try to make an old `PandratorInstaller.exe` a Manager by setting environment
+variables or by relying on its process tree.
+
 Inspect legacy state without changing it:
 
 ```bash

--- a/pixi.lock
+++ b/pixi.lock
@@ -600,6 +600,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/27/1b/16ab7f2cf2041da2f60d156ba64c2484eadf9168075b4ff43c3ef60045af/propcache-0.5.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/34/20/f9453db785f3dbb4dd6b44aa073a3b2fcbde5e91b8746c769d348345d105/wtpsplit_lite-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/c2/080f16cf870e929e592f55767f01d6c98d2ee83bfdc36c3b892f2d0459ab/greenlet-3.5.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
@@ -648,11 +649,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a5/b9/2b8f0c0ce09c87a1daf80fd483431b56b1435d3f62789bc86f572e1245de/aiohttp-3.14.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/e5/aa1e81b21aea0ce0ba435311837a37d4cb936e7461f9fecac08580073ba9/build-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/41/1174945272c2d5331d5e49d29110c95e24458d681d4949ffef3b67210745/deepl-1.30.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fa/e19012d6a2584de17ef74b00cc49295d76dc104152118a7bc244ee18f2c3/hasami-0.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/0d/6ee861c53f3f7e6c5dd34a441d17aad1dfb3d50ce1f1a024cc9194ac3db3/pyqt6_sip-13.11.1-cp311-cp311-manylinux1_x86_64.manylinux_2_5_x86_64.whl
@@ -778,6 +781,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/34/20/f9453db785f3dbb4dd6b44aa073a3b2fcbde5e91b8746c769d348345d105/wtpsplit_lite-0.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/8c/da17d91fc56532b36a27109447016d67e4618afc4447e8c4023240e920f5/litellm-1.91.4-py3-none-any.whl
@@ -827,6 +831,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ab/e5/aa1e81b21aea0ce0ba435311837a37d4cb936e7461f9fecac08580073ba9/build-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ad/fd/005bf80f3cf6e5c62b5dd68616280f51cd012c60840fa74781b3ed7b1623/sqlalchemy-2.0.51-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/41/1174945272c2d5331d5e49d29110c95e24458d681d4949ffef3b67210745/deepl-1.30.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/61/0ab90f421c6194705a99d0fa9f6ee2045d916e4455fdbb095a9c2c9a520f/cryptography-45.0.7-cp311-abi3-win_amd64.whl
@@ -834,6 +839,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fa/e19012d6a2584de17ef74b00cc49295d76dc104152118a7bc244ee18f2c3/hasami-0.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/cd/7d/8711a75cb61d85246277c07ff6e1a6504621ba473d808c11ad225ffca43f/greenlet-3.5.4-cp311-cp311-win_amd64.whl
@@ -6116,6 +6122,13 @@ packages:
   - rpds-py>=0.7.0
   - typing-extensions>=4.4.0 ; python_full_version < '3.13'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl
+  name: wheel
+  version: 0.48.0
+  sha256: 3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab
+  requires_dist:
+  - packaging>=24.0
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl
   name: pymupdf
   version: 1.28.0
@@ -6950,6 +6963,20 @@ packages:
   requires_dist:
   - typing-extensions>=4.14.1
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ab/e5/aa1e81b21aea0ce0ba435311837a37d4cb936e7461f9fecac08580073ba9/build-1.6.0-py3-none-any.whl
+  name: build
+  version: 1.6.0
+  sha256: f7aaf1ebbb79178a02ba248bb524f2176b256017e17e8e4bd4289c7b38cc2bad
+  requires_dist:
+  - packaging>=24.0
+  - pyproject-hooks
+  - colorama ; os_name == 'nt'
+  - importlib-metadata>=4.6 ; python_full_version < '3.10.2'
+  - tomli>=1.1.0 ; python_full_version < '3.11'
+  - keyring ; extra == 'keyring'
+  - uv>=0.1.18 ; extra == 'uv'
+  - virtualenv>=20.36.1 ; extra == 'virtualenv'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/ad/fd/005bf80f3cf6e5c62b5dd68616280f51cd012c60840fa74781b3ed7b1623/sqlalchemy-2.0.51-cp311-cp311-win_amd64.whl
   name: sqlalchemy
   version: 2.0.51
@@ -7133,6 +7160,11 @@ packages:
   - babel ; extra == 'babel'
   - lingua ; extra == 'lingua'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+  name: pyproject-hooks
+  version: 1.2.0
+  sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/bf/ee/aa015c5de8b0dc42a8e507eae8c2de5d1c0e068c896858fec6d502402ed6/ebooklib-0.20-py3-none-any.whl
   name: ebooklib
   version: '0.20'

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,8 @@ check-requirements = "python scripts/generate_requirements.py --check"
 smoke-dubbing-local = "python scripts/dubbing_live_smoke.py"
 
 [feature.installer-build.pypi-dependencies]
+build = ">=1.2,<2"
+wheel = "*"
 PyInstaller = "==6.20.0"
 PyQt6 = "==6.7.1"
 requests = "*"

--- a/scripts/build_installer.py
+++ b/scripts/build_installer.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -15,23 +16,26 @@ def build_linux_appimage(repo_root: Path) -> int:
 
 
 def build_windows_executable(repo_root: Path) -> int:
-    spec_path = repo_root / "pandrator_installer_launcher.spec"
-    executable = repo_root / "dist" / "PandratorInstaller.exe"
+    """Build the Manager bootstrap under the historical Windows filename.
 
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "PyInstaller",
-            "--clean",
-            "--noconfirm",
-            str(spec_path),
-        ],
-        check=True,
-        cwd=repo_root,
-    )
-    subprocess.run([str(executable), "--self-check"], check=True, cwd=repo_root)
-    print(f"Built and verified installer: {executable}")
+    ``PandratorInstaller.exe`` used to embed the Qt installer and its own
+    unauthenticated process supervisor.  Retain the familiar download name
+    for one-time migrations, but make its payload the current Manager
+    bootstrap so every normal launch enters the authenticated manager
+    lifecycle.
+    """
+
+    from build_manager_bootstrap import main as build_manager_bootstrap
+
+    if build_manager_bootstrap([]) != 0:
+        raise RuntimeError("Pandrator Manager bootstrap build failed.")
+    bootstrap = repo_root / "dist" / "PandratorManagerBootstrap.exe"
+    executable = repo_root / "dist" / "PandratorInstaller.exe"
+    if not bootstrap.is_file():
+        raise RuntimeError(f"Manager bootstrap output missing: {bootstrap}")
+    shutil.copy2(bootstrap, executable)
+    subprocess.run([str(executable), "self-check"], check=True, cwd=repo_root)
+    print(f"Built and verified Manager-based installer: {executable}")
     return 0
 
 

--- a/scripts/build_manager_bootstrap.py
+++ b/scripts/build_manager_bootstrap.py
@@ -118,11 +118,16 @@ def _build_temporary_wheel(repo_root: Path, destination: Path) -> Path:
             "-m",
             "build",
             "--wheel",
+            "--no-isolation",
             "--outdir",
             str(destination),
             str(source),
         ],
-        cwd=repo_root,
+        # Invoke the build frontend from the staged source, not the checkout.
+        # A previous PyInstaller build leaves ``<repo>/build`` behind; from the
+        # repository root that directory shadows the third-party ``build``
+        # module and makes ``python -m build`` fail before packaging begins.
+        cwd=source,
         check=True,
     )
     return _wheel_from_directory(destination)

--- a/scripts/build_release_packages.py
+++ b/scripts/build_release_packages.py
@@ -361,8 +361,7 @@ def resolve_installer_executable(explicit_path: str | None, repo_root: Path) -> 
         return installer_path
 
     candidate_paths = (
-        repo_root / "dist" / "PandratorInstaller.exe",
-        repo_root / "dist" / "pandrator_installer_launcher.exe",
+        repo_root / "dist" / "PandratorManagerBootstrap.exe",
     )
     for candidate in candidate_paths:
         if candidate.exists():
@@ -715,7 +714,10 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--installer-exe",
         default=None,
-        help="Path to installer executable (defaults to dist/PandratorInstaller.exe).",
+        help=(
+            "Path to the Manager bootstrap executable "
+            "(defaults to dist/PandratorManagerBootstrap.exe)."
+        ),
     )
     parser.add_argument(
         "-o",

--- a/tests/test_build_release_packages.py
+++ b/tests/test_build_release_packages.py
@@ -1,4 +1,5 @@
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -11,6 +12,24 @@ import build_release_packages
 
 
 class BuildReleasePackagesTests(unittest.TestCase):
+    def test_default_release_bootstrap_is_the_manager_not_legacy_installer(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dist = root / "dist"
+            dist.mkdir()
+            legacy = dist / "PandratorInstaller.exe"
+            legacy.write_bytes(b"legacy supervisor")
+
+            with self.assertRaisesRegex(RuntimeError, "installer executable"):
+                build_release_packages.resolve_installer_executable(None, root)
+
+            bootstrap = dist / "PandratorManagerBootstrap.exe"
+            bootstrap.write_bytes(b"manager bootstrap")
+            self.assertEqual(
+                bootstrap,
+                build_release_packages.resolve_installer_executable(None, root),
+            )
+
     def test_resolve_dependencies_single_no_deps(self):
         # A component like kokoro has no dependencies
         resolved = build_release_packages.resolve_dependencies(["kokoro"])

--- a/tests/test_manager_build.py
+++ b/tests/test_manager_build.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from unittest import mock
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
@@ -25,6 +26,7 @@ from cryptography.hazmat.primitives.serialization import (
 from pandrator_manager.releases.trust import TrustStore
 from scripts.build_manager_appimage import stage_appdir, write_checksum
 from scripts.build_manager_bootstrap import (
+    _build_temporary_wheel,
     _extract_wheel,
     _stage_wheel_source,
     _verify_wheel_provenance,
@@ -40,6 +42,36 @@ from scripts.qualify_manager_lifecycle import _default_bundle_path
 
 
 class ManagerBootstrapBuildTests(unittest.TestCase):
+    def test_temporary_wheel_build_runs_outside_checkout_build_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            repository = root / "repository"
+            package = repository / "pandrator_manager"
+            package.mkdir(parents=True)
+            (package / "__init__.py").write_text("", encoding="utf-8")
+            (package / "pyproject.toml").write_text(
+                "[build-system]\nrequires = ['setuptools']\n"
+                "build-backend = 'setuptools.build_meta'\n",
+                encoding="utf-8",
+            )
+            # This is the path that shadowed the build frontend in practice.
+            (repository / "build").mkdir()
+            destination = root / "wheel"
+
+            with mock.patch(
+                "scripts.build_manager_bootstrap.subprocess.run"
+            ) as run, mock.patch(
+                "scripts.build_manager_bootstrap._wheel_from_directory",
+                return_value=destination / "fixture.whl",
+            ):
+                _build_temporary_wheel(repository, destination)
+
+            self.assertEqual(
+                destination.parent / "source",
+                run.call_args.kwargs["cwd"],
+            )
+            self.assertIn("--no-isolation", run.call_args.args[0])
+
     def test_release_checksum_manifest_is_single_sorted_file(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             root = Path(raw)

--- a/tests/test_manager_network.py
+++ b/tests/test_manager_network.py
@@ -138,6 +138,28 @@ class NetworkConfigurationTests(unittest.TestCase):
         )
         self.assertNotIn("PANDRATOR_OWNER_PASSWORD", worker.environment)
 
+    def test_managed_web_runtime_receives_authenticated_manager_handoff(self):
+        with tempfile.TemporaryDirectory() as directory:
+            layout = WorkspaceLayout.from_value(directory)
+            layout.ensure_base_directories()
+            api, worker = pandrator_runtime_specs(layout)
+
+        expected = {
+            "PANDRATOR_MANAGER_DESCRIPTOR": str(layout.descriptor),
+            "PANDRATOR_MANAGER_CREDENTIAL": str(layout.credential),
+        }
+        self.assertTrue(
+            expected.items() <= api.environment.items(),
+            "the supervised API subprocess must receive the Manager handoff",
+        )
+        self.assertTrue(
+            expected.items() <= worker.environment.items(),
+            "the supervised worker subprocess must receive the Manager handoff",
+        )
+        self.assertIn("serve", api.arguments)
+        self.assertIn("worker", worker.arguments)
+
+
     def test_legacy_source_without_public_url_option_remains_launchable(self):
         with tempfile.TemporaryDirectory() as directory:
             layout = WorkspaceLayout.from_value(directory)

--- a/tests/test_web_manager_proxy.py
+++ b/tests/test_web_manager_proxy.py
@@ -16,6 +16,19 @@ from pandrator.web.manager_proxy import (
 
 
 class LocalManagerProxyTests(unittest.TestCase):
+    def test_standalone_runtime_without_handoff_remains_unmanaged(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PANDRATOR_MANAGER_DESCRIPTOR": "",
+                "PANDRATOR_MANAGER_CREDENTIAL": "",
+            },
+        ):
+            with self.assertRaises(ManagerProxyError) as raised:
+                LocalManagerProxy().discover()
+
+        self.assertEqual("manager_not_configured", raised.exception.code)
+
     def test_discovery_rejects_non_loopback_descriptor(self):
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory)


### PR DESCRIPTION
## Summary

Migrates the Windows launcher from the legacy direct-supervision model to the current authenticated Pandrator Manager architecture.

The legacy `PandratorInstaller.exe` directly launched and supervised Pandrator, its worker, and selected services. Current Pandrator expects Manager-launched runtimes to receive the authenticated `PANDRATOR_MANAGER_DESCRIPTOR` / `PANDRATOR_MANAGER_CREDENTIAL` handoff. Because the legacy launcher did not provide that contract, Pandrator incorrectly appeared as unmanaged in **Providers & services** even when it had been launched through the installer.

This change makes the supported Windows build emit the current Manager bootstrap under the familiar `PandratorInstaller.exe` compatibility filename and prevents normal Windows release packaging from silently preferring the legacy supervisor.

## Changes

- Build the validated Pandrator Manager bootstrap as `PandratorInstaller.exe` for Windows migration compatibility.
- Default Windows release packaging to `PandratorManagerBootstrap.exe` rather than the legacy supervisor.
- Harden the bootstrap build path so it works from non-clean workspaces and does not conflict with the repository `build/` directory.
- Add missing `build` / `wheel` dependencies to the `installer-build` environment.
- Add regression coverage for:
  - authenticated Manager handoff to managed web/worker runtimes;
  - standalone runtimes remaining unmanaged;
  - release packaging refusing a lone legacy Windows installer artifact.
- Document the one-time migration path for existing users of the legacy launcher.

## Validation

- Built the actual Windows bootstrap successfully with:
  - `PandratorManagerBootstrap.exe`
  - `PandratorInstaller.exe`
- Verified the built executable can:
  - initialize a fresh workspace;
  - start a live authenticated Manager daemon;
  - create Manager descriptor/credential state;
  - launch real Pandrator `serve` and `worker` processes through Manager runtime specs;
  - pass the Manager handoff automatically to both processes;
  - return `/api/v1/manager/status` with `available: true`;
  - shut down cleanly and remove Manager descriptor state.
- Verified standalone Pandrator without Manager handoff still reports `manager_not_configured`.
- Targeted tests: 69 passed, 1 expected skip.
- `compileall` passed.
- `git diff --check` passed.

## Scope / known limitations

This PR intentionally targets the Windows launcher migration only.

The following were discovered during validation but are separate release/infrastructure issues:

- the current public Manager release manifest is signed with a newer trust key than this checkout embeds;
- the latest public release does not include a signed Pandrator application-release manifest;
- no Qwen/Kobold component artifact is currently published in the release assets;
- the Linux/AppImage build path still contains the legacy Qt supervisor and should be migrated separately.

No Manager authentication or trust checks are weakened by this change.