### PR TITLE
Make manager handoff preparation crash-resumable

### DIFF
--- a/pandrator_manager/releases/handoff.py
+++ b/pandrator_manager/releases/handoff.py
@@ -33,7 +33,7 @@ from pydantic import Field
 from .. import __version__
 from ..auth import protect_path, read_client_secret
 from ..context import WorkspaceLayout
-from ..errors import ConflictError, ManagerError
+from ..errors import ConflictError, ManagerError, UnsafePathError
 from ..launcher import (
     LauncherRuntime,
     current_runtime_executable,
@@ -84,6 +84,29 @@ class ManagerHandoffPayload(StrictModel):
 
 class ManagerHandoffEnvelope(StrictModel):
     payload: ManagerHandoffPayload
+    authentication: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class ManagerPreparationPayload(StrictModel):
+    schema_version: Literal[1] = 1
+    operation_id: str = Field(pattern=_OPERATION_ID_PATTERN)
+    workspace: str
+    expected_revision: int = Field(ge=0)
+    product: Literal["pandrator-manager"]
+    channel: Literal["stable", "beta", "nightly"]
+    version: str
+    sequence: int = Field(ge=1)
+    manifest_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    envelope: dict[str, Any]
+    artifact: dict[str, Any]
+    verified_key_ids: tuple[str, ...]
+    staged_path: str
+    destination_path: str
+    created_at: datetime
+
+
+class ManagerPreparationEnvelope(StrictModel):
+    payload: ManagerPreparationPayload
     authentication: str = Field(pattern=r"^[0-9a-f]{64}$")
 
 
@@ -169,6 +192,15 @@ def handoff_descriptor_path(
     return layout.require_within(path, roots=(layout.state,))
 
 
+def preparation_journal_path(
+    layout: WorkspaceLayout,
+    operation_id: str,
+) -> Path:
+    selected = _validated_operation_id(operation_id)
+    path = _safe_handoff_directory(layout) / f"{selected}.prepare"
+    return layout.require_within(path, roots=(layout.state,))
+
+
 def _authentication(payload: Mapping[str, Any], secret: str) -> str:
     return hmac.new(
         secret.encode("utf-8"),
@@ -180,6 +212,23 @@ def _authentication(payload: Mapping[str, Any], secret: str) -> str:
 def _write_envelope(
     path: Path,
     payload: ManagerHandoffPayload,
+    secret: str,
+) -> None:
+    raw_payload = payload.model_dump(mode="json")
+    _atomic_json(
+        path,
+        {
+            "payload": raw_payload,
+            "authentication": _authentication(raw_payload, secret),
+        },
+    )
+    protect_path(path.parent, directory=True)
+    protect_path(path)
+
+
+def _write_preparation_journal(
+    path: Path,
+    payload: ManagerPreparationPayload,
     secret: str,
 ) -> None:
     raw_payload = payload.model_dump(mode="json")
@@ -239,6 +288,198 @@ def read_handoff(
     return envelope, path
 
 
+def read_preparation_journal(
+    layout: WorkspaceLayout,
+    operation_id: str,
+) -> tuple[ManagerPreparationEnvelope, Path]:
+    path = preparation_journal_path(layout, operation_id)
+    _require_regular_control_file(
+        path,
+        label="manager handoff preparation journal",
+    )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        envelope = ManagerPreparationEnvelope.model_validate(raw)
+    except Exception as error:
+        raise ManagerError(
+            "invalid_manager_handoff",
+            "The manager handoff preparation journal is invalid.",
+            {"operation_id": operation_id, "reason": str(error)},
+            500,
+        ) from error
+    if (
+        envelope.payload.operation_id != operation_id
+        or Path(envelope.payload.workspace).resolve(strict=False)
+        != layout.workspace
+    ):
+        raise ManagerError(
+            "invalid_manager_handoff",
+            "The manager handoff preparation journal belongs to another operation or workspace.",
+            {"operation_id": operation_id},
+            500,
+        )
+    try:
+        layout.require_within(
+            envelope.payload.staged_path,
+            roots=(layout.staging,),
+        )
+        layout.require_within(
+            envelope.payload.destination_path,
+            roots=(layout.manager_versions,),
+        )
+    except UnsafePathError as error:
+        raise ManagerError(
+            "invalid_manager_handoff",
+            "The manager handoff preparation journal has unsafe paths.",
+            {"operation_id": operation_id},
+            500,
+        ) from error
+    secret = read_client_secret(layout.credential)
+    expected = _authentication(
+        envelope.payload.model_dump(mode="json"),
+        secret,
+    )
+    if not hmac.compare_digest(expected, envelope.authentication):
+        raise ManagerError(
+            "invalid_manager_handoff",
+            "The manager handoff preparation journal failed authentication.",
+            {"operation_id": operation_id},
+            500,
+        )
+    return envelope, path
+
+
+def _validate_reviewed_manager_preparation(
+    *,
+    layout: WorkspaceLayout,
+    store: ManagerStore,
+    operation_id: str,
+    expected_revision: int,
+    release: VerifiedRelease,
+    staged: Path,
+    destination: Path,
+    preparation: ManagerPreparationPayload | None = None,
+) -> None:
+    if release.manifest.payload.product != "pandrator-manager":
+        raise ValueError("Manager handoff requires a manager release.")
+    operation = store.get_operation(operation_id)
+    plan = store.get_plan(operation.plan_id)
+    release_impact = plan.impacts.get("release")
+    artifact = release.artifact.model_dump(mode="json")
+    if (
+        operation.kind != OperationKind.UPDATE
+        or operation.state != OperationState.RUNNING
+        or plan.kind != OperationKind.UPDATE
+        or plan.workspace != str(layout.workspace)
+        or plan.expected_revision != expected_revision
+        or not isinstance(release_impact, dict)
+        or release_impact.get("product") != "pandrator-manager"
+        or release_impact.get("channel") != release.manifest.payload.channel
+        or release_impact.get("version") != release.manifest.payload.version
+        or release_impact.get("sequence") != release.manifest.payload.sequence
+        or release_impact.get("manifest_digest") != release.manifest.digest
+        or release_impact.get("artifact") != artifact
+    ):
+        raise ManagerError(
+            "invalid_manager_handoff",
+            "The pending handoff does not match its reviewed release plan.",
+            {"operation_id": operation_id},
+            500,
+        )
+    if preparation is not None and (
+        preparation.operation_id != operation_id
+        or Path(preparation.workspace).resolve(strict=False) != layout.workspace
+        or preparation.expected_revision != expected_revision
+        or preparation.product != "pandrator-manager"
+        or preparation.channel != release.manifest.payload.channel
+        or preparation.version != release.manifest.payload.version
+        or preparation.sequence != release.manifest.payload.sequence
+        or preparation.manifest_digest != release.manifest.digest
+        or preparation.envelope != release.envelope
+        or preparation.artifact != artifact
+        or preparation.verified_key_ids != release.manifest.verified_key_ids
+        or layout.require_within(
+            preparation.staged_path,
+            roots=(layout.staging,),
+        ).resolve(strict=False)
+        != staged.resolve(strict=False)
+        or layout.require_within(
+            preparation.destination_path,
+            roots=(layout.manager_versions,),
+        ).resolve(strict=False)
+        != destination.resolve(strict=False)
+    ):
+        raise ManagerError(
+            "invalid_manager_handoff",
+            "The manager handoff preparation journal does not match the reviewed release.",
+            {"operation_id": operation_id},
+            500,
+        )
+
+
+def _move_prepared_manager_release(staged: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(staged, destination)
+
+
+def _handoff_payload(
+    *,
+    layout: WorkspaceLayout,
+    operation_id: str,
+    expected_revision: int,
+    release: VerifiedRelease,
+    validated,
+) -> ManagerHandoffPayload:
+    pointer = layout.root / "manager" / "current.json"
+    try:
+        previous = json.loads(pointer.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        previous = None
+    current = psutil.Process()
+    return ManagerHandoffPayload(
+        operation_id=operation_id,
+        workspace=str(layout.workspace),
+        expected_revision=expected_revision,
+        channel=release.manifest.payload.channel,
+        version=release.manifest.payload.version,
+        sequence=release.manifest.payload.sequence,
+        manifest_digest=release.manifest.digest,
+        envelope=release.envelope,
+        artifact=release.artifact.model_dump(mode="json"),
+        verified_key_ids=release.manifest.verified_key_ids,
+        slot_path=str(validated.root),
+        new_python=str(validated.python),
+        new_runtime_mode=validated.metadata.runtime_kind,
+        new_application_root=str(validated.application_root),
+        old_python=str(current_runtime_executable()),
+        old_runtime_mode=(
+            "native_launcher" if bool(getattr(sys, "frozen", False)) else "python"
+        ),
+        old_cwd=str(Path.cwd().resolve(strict=False)),
+        old_pid=current.pid,
+        old_create_time=current.create_time(),
+        previous_pointer=previous if isinstance(previous, dict) else None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _remove_preparation_journal(path: Path) -> None:
+    _require_regular_control_file(path, label="manager handoff preparation journal")
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _cleanup_preparation_journal(path: Path) -> None:
+    try:
+        _remove_preparation_journal(path)
+    except OSError:
+        # The final handoff descriptor is already durable and authenticated.
+        # Retain redundant cleanup state rather than rolling back that handoff.
+        pass
+
+
 def prepare_manager_handoff(
     *,
     layout: WorkspaceLayout,
@@ -252,10 +493,11 @@ def prepare_manager_handoff(
         raise ValueError("Manager handoff requires a manager release.")
     _safe_handoff_directory(layout, create=True)
     descriptor = handoff_descriptor_path(layout, operation_id)
-    versions = layout.manager_versions
+    journal = preparation_journal_path(layout, operation_id)
+    staged = layout.require_within(staged_directory, roots=(layout.staging,))
     destination = layout.require_within(
-        versions / release.manifest.payload.version,
-        roots=(versions,),
+        layout.manager_versions / release.manifest.payload.version,
+        roots=(layout.manager_versions,),
     )
     secret = read_client_secret(layout.credential)
     if descriptor.is_file():
@@ -272,65 +514,85 @@ def prepare_manager_handoff(
                 {"operation_id": operation_id},
                 500,
             )
+        if os.path.lexists(journal):
+            preparation, journal_path = read_preparation_journal(layout, operation_id)
+            _validate_reviewed_manager_preparation(
+                layout=layout, store=store, operation_id=operation_id,
+                expected_revision=expected_revision, release=release, staged=staged,
+                destination=destination, preparation=preparation.payload,
+            )
+            _cleanup_preparation_journal(journal_path)
     else:
-        staged = layout.require_within(
-            staged_directory,
-            roots=(layout.staging,),
-        )
-        if destination.exists():
-            raise ConflictError(
-                "The manager release version already has a slot.",
-                {"version": release.manifest.payload.version},
+        preparation: ManagerPreparationPayload
+        if os.path.lexists(journal):
+            preparation, _ = read_preparation_journal(layout, operation_id)
+            _validate_reviewed_manager_preparation(
+                layout=layout, store=store, operation_id=operation_id,
+                expected_revision=expected_revision, release=release, staged=staged,
+                destination=destination, preparation=preparation.payload,
             )
-        if not staged.is_dir():
-            raise ManagerError(
-                "invalid_release_bundle",
-                "The staged manager bundle is missing.",
-                http_status=409,
+            if staged.exists() and destination.exists():
+                raise ManagerError(
+                    "invalid_manager_handoff",
+                    "The manager handoff preparation has both staging and destination slots.",
+                    {"operation_id": operation_id}, 409,
+                )
+            if staged.exists():
+                if not staged.is_dir():
+                    raise ManagerError(
+                        "invalid_release_bundle",
+                        "The staged manager bundle is missing.",
+                        http_status=409,
+                    )
+                _move_prepared_manager_release(staged, destination)
+            elif not destination.exists():
+                raise ManagerError(
+                    "invalid_manager_handoff",
+                    "The manager handoff preparation has neither staging nor destination slot.",
+                    {"operation_id": operation_id}, 409,
+                )
+        else:
+            _validate_reviewed_manager_preparation(
+                layout=layout, store=store, operation_id=operation_id,
+                expected_revision=expected_revision, release=release, staged=staged,
+                destination=destination,
             )
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        os.replace(staged, destination)
+            if destination.exists():
+                raise ConflictError(
+                    "The manager release version already has a slot.",
+                    {"version": release.manifest.payload.version},
+                )
+            if not staged.is_dir():
+                raise ManagerError(
+                    "invalid_release_bundle",
+                    "The staged manager bundle is missing.",
+                    http_status=409,
+                )
+            preparation = ManagerPreparationPayload(
+                operation_id=operation_id, workspace=str(layout.workspace),
+                expected_revision=expected_revision, product="pandrator-manager",
+                channel=release.manifest.payload.channel,
+                version=release.manifest.payload.version,
+                sequence=release.manifest.payload.sequence,
+                manifest_digest=release.manifest.digest, envelope=release.envelope,
+                artifact=release.artifact.model_dump(mode="json"),
+                verified_key_ids=release.manifest.verified_key_ids,
+                staged_path=str(staged), destination_path=str(destination),
+                created_at=datetime.now(timezone.utc),
+            )
+            _write_preparation_journal(journal, preparation, secret)
+            _move_prepared_manager_release(staged, destination)
         validated = validate_release_bundle(
-            destination,
-            product="pandrator-manager",
+            destination, product="pandrator-manager",
             version=release.manifest.payload.version,
         )
-        pointer = layout.root / "manager" / "current.json"
-        try:
-            previous = json.loads(pointer.read_text(encoding="utf-8"))
-        except (OSError, TypeError, ValueError, json.JSONDecodeError):
-            previous = None
-        current = psutil.Process()
-        payload = ManagerHandoffPayload(
-            operation_id=operation_id,
-            workspace=str(layout.workspace),
-            expected_revision=expected_revision,
-            channel=release.manifest.payload.channel,
-            version=release.manifest.payload.version,
-            sequence=release.manifest.payload.sequence,
-            manifest_digest=release.manifest.digest,
-            envelope=release.envelope,
-            artifact=release.artifact.model_dump(mode="json"),
-            verified_key_ids=release.manifest.verified_key_ids,
-            slot_path=str(validated.root),
-            new_python=str(validated.python),
-            new_runtime_mode=validated.metadata.runtime_kind,
-            new_application_root=str(validated.application_root),
-            old_python=str(current_runtime_executable()),
-            old_runtime_mode=(
-                "native_launcher"
-                if bool(getattr(sys, "frozen", False))
-                else "python"
-            ),
-            old_cwd=str(Path.cwd().resolve(strict=False)),
-            old_pid=current.pid,
-            old_create_time=current.create_time(),
-            previous_pointer=(
-                previous if isinstance(previous, dict) else None
-            ),
-            created_at=datetime.now(timezone.utc),
+        payload = _handoff_payload(
+            layout=layout, operation_id=operation_id,
+            expected_revision=expected_revision, release=release,
+            validated=validated,
         )
         _write_envelope(descriptor, payload, secret)
+        _cleanup_preparation_journal(journal)
     # Revalidate all persisted paths on resume.
     slot = layout.require_within(
         payload.slot_path,
@@ -416,24 +678,58 @@ def rollback_prepared_manager_handoff(
     result: Mapping[str, Any] | None = None,
 ) -> None:
     descriptor = handoff_descriptor_path(layout, operation_id)
+    journal = preparation_journal_path(layout, operation_id)
+    slots: list[Path] = []
     slot_value = (result or {}).get("slot_path")
-    if slot_value is None and descriptor.is_file():
-        try:
-            envelope, _ = read_handoff(layout, operation_id)
-            slot_value = envelope.payload.slot_path
-        except Exception:
-            slot_value = None
     if isinstance(slot_value, str):
-        slot = layout.require_within(
-            slot_value,
-            roots=(layout.manager_versions,),
+        slots.append(
+            layout.require_within(
+                slot_value,
+                roots=(layout.manager_versions,),
+            )
         )
+    if os.path.lexists(descriptor):
+        envelope, _ = read_handoff(layout, operation_id)
+        slots.append(
+            layout.require_within(
+                envelope.payload.slot_path,
+                roots=(layout.manager_versions,),
+            )
+        )
+    journal_path: Path | None = None
+    if os.path.lexists(journal):
+        preparation, journal_path = read_preparation_journal(
+            layout,
+            operation_id,
+        )
+        slots.append(
+            layout.require_within(
+                preparation.payload.destination_path,
+                roots=(layout.manager_versions,),
+            )
+        )
+    if slots:
+        slot = slots[0]
+        if any(
+            candidate.resolve(strict=False) != slot.resolve(strict=False)
+            for candidate in slots[1:]
+        ):
+            raise ManagerError(
+                "invalid_manager_handoff",
+                "Manager handoff rollback state does not agree on the prepared slot.",
+                {"operation_id": operation_id},
+                500,
+            )
         if slot.exists():
             shutil.rmtree(slot)
-    try:
+    if os.path.lexists(descriptor):
+        _require_regular_control_file(
+            descriptor,
+            label="manager handoff descriptor",
+        )
         descriptor.unlink()
-    except FileNotFoundError:
-        pass
+    if journal_path is not None:
+        _remove_preparation_journal(journal_path)
 
 
 class ManagerHandoffCoordinator:

--- a/tests/test_manager_releases.py
+++ b/tests/test_manager_releases.py
@@ -21,7 +21,7 @@ from pandrator_manager.api import create_api
 from pandrator_manager.application import create_application
 from pandrator_manager.auth import ensure_client_secret
 from pandrator_manager.errors import ConflictError, ManagerError
-from pandrator_manager.models import HealthResult, HealthState, OperationState
+from pandrator_manager.models import HealthResult, HealthState, OperationState, TaskState
 from pandrator_manager.operations import OperationEngine
 from pandrator_manager.releases import (
     ReleaseActivationError,
@@ -974,6 +974,369 @@ class DurableApplicationReleaseTests(unittest.TestCase):
         )
         with self.assertRaises(ConflictError):
             self.application.store.request_cancellation(operation.id)
+
+    def test_manager_handoff_preparation_resumes_after_crash_before_descriptor(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_write_envelope",
+            side_effect=SystemExit,
+        ):
+            with self.assertRaises(SystemExit):
+                engine._execute(operation.id)
+
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertFalse(
+            handoff_module.handoff_descriptor_path(
+                self.layout,
+                operation.id,
+            ).exists()
+        )
+        self.assertEqual(pending_handoffs(self.layout), ())
+        interrupted = self.application.store.get_operation(operation.id)
+        self.assertEqual(interrupted.state, OperationState.RUNNING)
+        handoff_task = next(
+            task
+            for task in self.application.store.operation_tasks(operation.id)
+            if task.task.kind == "prepare_manager_handoff"
+        )
+        self.assertEqual(handoff_task.state, TaskState.RUNNING)
+
+        engine._recover_interrupted()
+        engine._execute(operation.id)
+
+        resumed = self.application.store.get_operation(operation.id)
+        self.assertEqual(resumed.state, OperationState.HANDOFF_PENDING)
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertEqual(pending_handoffs(self.layout), (operation.id,))
+        envelope, _path = read_handoff(self.layout, operation.id)
+        self.assertEqual(envelope.payload.version, "1.0.0")
+        self.assertEqual(
+            envelope.payload.manifest_digest,
+            plan.impacts["release"]["manifest_digest"],
+        )
+
+    def test_manager_handoff_preparation_resumes_after_crash_before_move(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_move_prepared_manager_release",
+            side_effect=SystemExit,
+        ):
+            with self.assertRaises(SystemExit):
+                engine._execute(operation.id)
+
+        self.assertTrue(
+            handoff_module.preparation_journal_path(
+                self.layout,
+                operation.id,
+            ).is_file()
+        )
+        self.assertFalse((self.layout.manager_versions / "1.0.0").exists())
+
+        engine._recover_interrupted()
+        engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.HANDOFF_PENDING,
+        )
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertFalse(
+            handoff_module.preparation_journal_path(
+                self.layout,
+                operation.id,
+            ).exists()
+        )
+
+    def test_manager_handoff_removes_stale_journal_after_descriptor_crash(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_remove_preparation_journal",
+            side_effect=SystemExit,
+        ):
+            with self.assertRaises(SystemExit):
+                engine._execute(operation.id)
+
+        journal = handoff_module.preparation_journal_path(
+            self.layout,
+            operation.id,
+        )
+        self.assertTrue(journal.is_file())
+        envelope, _path = read_handoff(self.layout, operation.id)
+        self.assertEqual(envelope.payload.version, "1.0.0")
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+
+        engine._recover_interrupted()
+        engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.HANDOFF_PENDING,
+        )
+        self.assertFalse(journal.exists())
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertEqual(pending_handoffs(self.layout), (operation.id,))
+        self.assertEqual(
+            read_handoff(self.layout, operation.id)[0].payload.manifest_digest,
+            plan.impacts["release"]["manifest_digest"],
+        )
+
+    def test_manager_handoff_keeps_descriptor_when_journal_cleanup_fails(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_remove_preparation_journal",
+            side_effect=PermissionError("journal is temporarily locked"),
+        ):
+            engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.HANDOFF_PENDING,
+        )
+        self.assertTrue(
+            handoff_module.handoff_descriptor_path(
+                self.layout,
+                operation.id,
+            ).is_file()
+        )
+        self.assertTrue(
+            handoff_module.preparation_journal_path(
+                self.layout,
+                operation.id,
+            ).is_file()
+        )
+        self.assertEqual(pending_handoffs(self.layout), (operation.id,))
+        self.assertEqual(
+            read_handoff(self.layout, operation.id)[0].payload.manifest_digest,
+            plan.impacts["release"]["manifest_digest"],
+        )
+
+    def test_manager_handoff_rejects_authenticated_journal_with_unsafe_path(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_write_envelope",
+            side_effect=SystemExit,
+        ):
+            with self.assertRaises(SystemExit):
+                engine._execute(operation.id)
+
+        outside_temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(outside_temporary.cleanup)
+        outside = Path(outside_temporary.name)
+        marker = outside / "must-not-be-deleted"
+        marker.write_text("outside", encoding="utf-8")
+        journal = handoff_module.preparation_journal_path(
+            self.layout,
+            operation.id,
+        )
+        document = json.loads(journal.read_text(encoding="utf-8"))
+        document["payload"]["staged_path"] = str(outside)
+        document["authentication"] = handoff_module._authentication(
+            document["payload"],
+            handoff_module.read_client_secret(self.layout.credential),
+        )
+        journal.write_text(json.dumps(document), encoding="utf-8")
+
+        engine._recover_interrupted()
+        engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.RECOVERY_REQUIRED,
+        )
+        self.assertTrue(marker.is_file())
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertTrue(journal.is_file())
+        self.assertEqual(pending_handoffs(self.layout), ())
+
+    def test_manager_handoff_rollback_rejects_disagreeing_slot_evidence(self):
+        _plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(_plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_remove_preparation_journal",
+            side_effect=SystemExit,
+        ):
+            with self.assertRaises(SystemExit):
+                engine._execute(operation.id)
+
+        other_slot = self.layout.manager_versions / "9.9.9"
+        other_slot.mkdir(parents=True)
+        marker = other_slot / "must-not-be-deleted"
+        marker.write_text("other slot", encoding="utf-8")
+        descriptor = handoff_module.handoff_descriptor_path(
+            self.layout,
+            operation.id,
+        )
+        journal = handoff_module.preparation_journal_path(
+            self.layout,
+            operation.id,
+        )
+
+        with self.assertRaises(ManagerError) as raised:
+            handoff_module.rollback_prepared_manager_handoff(
+                layout=self.layout,
+                operation_id=operation.id,
+                result={"slot_path": str(other_slot)},
+            )
+
+        self.assertEqual(raised.exception.code, "invalid_manager_handoff")
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertTrue(marker.is_file())
+        self.assertTrue(descriptor.is_file())
+        self.assertTrue(journal.is_file())
+
+    def test_manager_handoff_rejects_unexplained_existing_slot(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        destination = self.layout.manager_versions / "1.0.0"
+        destination.mkdir(parents=True)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.FAILED,
+        )
+        self.assertTrue(destination.is_dir())
+        self.assertFalse(
+            handoff_module.preparation_journal_path(
+                self.layout,
+                operation.id,
+            ).exists()
+        )
+
+    def test_manager_handoff_rollback_cleans_authenticated_preparation_journal(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_write_envelope",
+            side_effect=RuntimeError("descriptor write failed"),
+        ):
+            engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.FAILED,
+        )
+        self.assertFalse((self.layout.manager_versions / "1.0.0").exists())
+        self.assertFalse(
+            handoff_module.preparation_journal_path(
+                self.layout,
+                operation.id,
+            ).exists()
+        )
+
+    def test_manager_handoff_rejects_tampered_preparation_journal(self):
+        plan = self._prepare_native_manager_plan()
+        operation = self._submit_manager_plan(plan)
+        engine = OperationEngine(
+            self.application.context,
+            self.application.store,
+            self.application.registry,
+            release_authority=self.application.release_authority,
+            manager_handoff_callback=lambda _execution, _result: None,
+        )
+
+        with mock.patch.object(
+            handoff_module,
+            "_write_envelope",
+            side_effect=SystemExit,
+        ):
+            with self.assertRaises(SystemExit):
+                engine._execute(operation.id)
+
+        journal = handoff_module.preparation_journal_path(
+            self.layout,
+            operation.id,
+        )
+        document = json.loads(journal.read_text(encoding="utf-8"))
+        document["authentication"] = "0" * 64
+        journal.write_text(json.dumps(document), encoding="utf-8")
+
+        engine._recover_interrupted()
+        engine._execute(operation.id)
+
+        self.assertEqual(
+            self.application.store.get_operation(operation.id).state,
+            OperationState.RECOVERY_REQUIRED,
+        )
+        self.assertTrue((self.layout.manager_versions / "1.0.0").is_dir())
+        self.assertTrue(journal.is_file())
+        self.assertEqual(pending_handoffs(self.layout), ())
 
     def test_handoff_directory_rejects_non_directory_redirection(self):
         directory = handoff_module.handoff_directory(self.layout)


### PR DESCRIPTION
### Problem

Native Manager self-update preparation moved the staged Manager release into its version slot before durably recording enough state to resume that move.

If the Manager process exited after the move but before the final authenticated handoff descriptor was written, restart recovery replayed the task, found the destination slot already present, and failed with `The manager release version already has a slot.` The orphaned slot could therefore prevent the interrupted update from resuming.

### Changes

- Add an authenticated preparation journal before moving the staged Manager release.
- Validate journal state against the operation, reviewed release plan, signed release identity, artifact, workspace, and contained staging/destination paths.
- Resume safely when interruption occurs before or after the staging-to-version-slot move.
- Preserve fail-closed behavior for unexplained pre-existing version slots and inconsistent recovery state.
- Require rollback evidence from task results, the final descriptor, and the preparation journal to agree before deleting a prepared slot.
- Treat failure to remove a redundant preparation journal after publication of the final authenticated descriptor as best-effort filesystem cleanup.
- Add regression coverage for crash boundaries, tampered/unsafe journals, rollback disagreement, and cleanup failure.

### Validation

- `python -m unittest tests.test_manager_releases` — captured full run: 30 tests passed.
- Focused Manager handoff regression tests passed.
- `python -m compileall -q pandrator_manager pandrator_manager_bootstrap.py` — passed after the final compatibility correction.
- `git diff --check` — passed after the final compatibility correction.
- Broader Pixi/Ruff validation could not be completed locally because the Windows Pixi environment fails while building `pynini` due to its `-Wno-register` compiler flag. Manager CI should exercise the clean Windows/Linux test matrix.

### Compatibility / safety

The existing final Manager handoff descriptor schema remains unchanged. Existing unexplained destination slots are still rejected, and persisted journal paths are authenticated and constrained to Manager-owned roots before they can authorize recovery or rollback deletion.